### PR TITLE
add __index support

### DIFF
--- a/SomethingNeedDoing/LuaMacro/Modules/ExcelModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/ExcelModule.cs
@@ -12,8 +12,7 @@ public class ExcelModule : LuaModuleBase
 {
     public override string ModuleName => "Excel";
 
-    [LuaFunction("__index")]
-    public ExcelSheetWrapper? this[LuaTable table, string key] => GetSheet(key);
+    protected override object? MetaIndex(LuaTable table, string key) => GetSheet(key);
 
     [LuaFunction]
     public ExcelSheetWrapper? GetSheet(string sheetName)


### PR DESCRIPTION
this makes *all* modules have a default metatable and all properties will be registered internally to be handled by the __index metamethod modules can "subscribe" to __index explicitly by overriding the `MetaIndex` method