### PR TITLE
Implemented ImGuiColorTextEditNetDalamud (Editor with highlighting)

### DIFF
--- a/SomethingNeedDoing/Gui/Editor/CodeEditor.cs
+++ b/SomethingNeedDoing/Gui/Editor/CodeEditor.cs
@@ -1,0 +1,74 @@
+﻿using ImGuiColorTextEditNet;
+using SomethingNeedDoing.Core.Interfaces;
+
+namespace SomethingNeedDoing.Gui.Editor;
+
+/// <summary>
+/// ImGuiColorTextEditNetDalamud TextEditor wrapper.
+/// </summary>
+public class CodeEditor
+{
+    private readonly TextEditor _editor = new();
+
+    private readonly Dictionary<MacroType, ISyntaxHighlighter> highlighters = new()
+    {
+        {MacroType.Lua, new LuaHighlighter()},
+        {MacroType.Native, new NativeMacroHighlighter()},
+    };
+
+    private IMacro? macro = null;
+
+    private string previousText = "";
+
+    public CodeEditor()
+    {
+        _editor.Renderer.Palette = EditorPalettes.Highlight;
+    }
+
+    public void SetMacro(IMacro macro)
+    {
+        if (this.macro?.Id == macro.Id)
+        {
+            return;
+        }
+
+        this.macro = macro;
+        _editor.AllText = macro.Content;
+        previousText = _editor.AllText;
+
+        if (highlighters.TryGetValue(macro.Type, out var highlighter))
+        {
+            _editor.SyntaxHighlighter = highlighter;
+        }
+    }
+
+    public void SetHighlightSyntax(bool highlightSyntax)
+    {
+        _editor.Renderer.Palette = highlightSyntax ? EditorPalettes.Highlight : EditorPalettes.NoHighlight;
+    }
+
+    public string GetContent() => _editor.AllText;
+
+    public bool HasChanged()
+    {
+        if (previousText != _editor.AllText)
+        {
+            previousText = _editor.AllText;
+            return true;
+        }
+
+        return false;
+    }
+
+    public bool Draw()
+    {
+        if (macro == null)
+        {
+            return false;
+        }
+
+        _editor.Render(macro.Name);
+
+        return HasChanged();
+    }
+}

--- a/SomethingNeedDoing/Gui/Editor/EditorPalettes.cs
+++ b/SomethingNeedDoing/Gui/Editor/EditorPalettes.cs
@@ -1,0 +1,60 @@
+namespace SomethingNeedDoing.Gui.Editor;
+
+/// <summary>
+/// Color palletes for the Code Editor.
+/// </summary>
+public static class EditorPalettes
+{
+    // All text is white, only background and highlight is dark
+    public static readonly uint[] NoHighlight = [
+        0xffffffff, // Default
+        0xffffffff, // Keyword
+        0xffffffff, // Number
+        0xffffffff, // String
+        0xffffffff, // CharLiteral
+        0xffffffff, // Punctuation
+        0xffffffff, // Preprocessor
+        0xffffffff, // Identifier
+        0xffffffff, // KnownIdentifier
+        0xffffffff, // PreprocIdentifier
+        0xffffffff, // Comment
+        0xffffffff, // MultiLineComment
+        0xff212121, // Background
+        0xffffffff, // Cursor
+        0xffffffff, // Selection
+        0xffffffff, // ErrorMarker
+        0xffffffff, // Breakpoint
+        0xffffffff, // LineNumber
+        0xffffffff, // CurrentLineFill
+        0x40282828, // CurrentLineFillInactive
+        0x403c3f41, // CurrentLineEdge
+        0xffffffff, // ExecutingLine
+        0xffffffff, // Function
+    ];
+
+    public static readonly uint[] Highlight = [
+        0xffc5c8c6, // Default
+        0xffc792ea, // Keyword
+        0xfff78c6c, // Number
+        0xffc3e88d, // String
+        0xfffcbf7e, // CharLiteral
+        0xff89ddff, // Punctuation
+        0xff82aaff, // Preprocessor
+        0xffd0d0d0, // Identifier
+        0xffaddb67, // KnownIdentifier
+        0xffffcb6b, // PreprocIdentifier
+        0xff616161, // Comment
+        0xff616161, // MultiLineComment
+        0xff212121, // Background
+        0xffffffff, // Cursor
+        0x8039adb5, // Selection
+        0x80ff5370, // ErrorMarker
+        0x40ffcb6b, // Breakpoint
+        0xff4a4a4a, // LineNumber
+        0x40282828, // CurrentLineFill
+        0x403c3f41, // CurrentLineFillInactive
+        0x403c3f41, // CurrentLineEdge
+        0xa03dd3b0, // ExecutingLine
+        0xffc792ea, // Function
+    ];
+}

--- a/SomethingNeedDoing/Gui/Editor/NativeMacroHighlightor.cs
+++ b/SomethingNeedDoing/Gui/Editor/NativeMacroHighlightor.cs
@@ -1,0 +1,105 @@
+using ImGuiColorTextEditNet;
+
+namespace SomethingNeedDoing.Gui.Editor;
+
+/// <summary>
+/// Highlighter implementation for native macros.
+///  - Highlights slash commands, string literal args and modifiers
+/// </summary>
+public class NativeMacroHighlighter : ISyntaxHighlighter
+{
+    static readonly object DefaultState = new();
+
+    public bool AutoIndentation => false;
+    public int MaxLinesPerFrame => 1000;
+    public string? GetTooltip(string id) => null;
+
+    public object Colorize(Span<Glyph> line, object? state)
+    {
+        int i = 0;
+        while (i < line.Length)
+        {
+            int result = Tokenize(line[i..]);
+            Util.Assert(result != 0);
+            i += result > 0 ? result : 1;
+        }
+
+        return state ?? DefaultState;
+    }
+
+    int Tokenize(Span<Glyph> span)
+    {
+        if (span.Length == 0)
+            return -1;
+
+        int result;
+        if ((result = TokenizeCommand(span)) != -1) return result;
+        if ((result = TokenizeArguments(span)) != -1) return result;
+        if ((result = TokenizeModifier(span)) != -1) return result;
+
+        return -1;
+    }
+
+    static int TokenizeCommand(Span<Glyph> span)
+    {
+        if (span[0].Char != '/')
+            return -1;
+
+        int i = 1;
+        while (i < span.Length && char.IsLetter(span[i].Char))
+        {
+            span[i] = new Glyph(span[i].Char, PaletteIndex.Keyword);
+            i++;
+        }
+
+        span[0] = new Glyph(span[0].Char, PaletteIndex.Keyword);
+        return i;
+    }
+
+    static int TokenizeArguments(Span<Glyph> span)
+    {
+        if (span[0].Char != '"')
+            return -1;
+
+        int i = 1;
+        while (i < span.Length)
+        {
+            if (span[i].Char == '"')
+            {
+                for (int j = 0; j <= i; j++)
+                    span[j] = new Glyph(span[j].Char, PaletteIndex.String);
+                return i + 1;
+            }
+            i++;
+        }
+
+        return -1;
+    }
+
+    static int TokenizeModifier(Span<Glyph> span)
+    {
+        if (span.Length < 3 || span[0].Char != '<')
+            return -1;
+
+        int i = 1;
+        while (i < span.Length && span[i].Char != '>')
+            i++;
+
+        if (i >= span.Length)
+            return -1;
+
+        for (int j = 0; j <= i; j++)
+        {
+            char c = span[j].Char;
+            PaletteIndex index = c switch
+            {
+                '<' or '>' or '.' => PaletteIndex.Punctuation,
+                >= '0' and <= '9' => PaletteIndex.KnownIdentifier,
+                _ => PaletteIndex.KnownIdentifier
+            };
+            span[j] = new Glyph(c, index);
+        }
+
+        return i + 1;
+    }
+}

--- a/SomethingNeedDoing/Gui/MacroEditor.cs
+++ b/SomethingNeedDoing/Gui/MacroEditor.cs
@@ -4,6 +4,7 @@ using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
 using ECommons.ImGuiMethods;
 using SomethingNeedDoing.Core.Interfaces;
+using SomethingNeedDoing.Gui.Editor;
 using SomethingNeedDoing.Managers;
 using System.Threading.Tasks;
 
@@ -19,6 +20,8 @@ public class MacroEditor(IMacroScheduler scheduler, GitMacroManager gitManager, 
     private bool _showLineNumbers = true;
     private bool _highlightSyntax = true;
     private UpdateState _updateState = UpdateState.Unknown;
+
+    private readonly CodeEditor _editor = new();
 
     private enum UpdateState
     {
@@ -37,6 +40,8 @@ public class MacroEditor(IMacroScheduler scheduler, GitMacroManager gitManager, 
             DrawEmptyState();
             return;
         }
+
+        _editor.SetMacro(macro);
 
         DrawEditorToolbar(macro);
         ImGui.Separator();
@@ -109,10 +114,11 @@ public class MacroEditor(IMacroScheduler scheduler, GitMacroManager gitManager, 
             _showLineNumbers = !_showLineNumbers;
 
         ImGui.SameLine();
-        if (ImGuiUtils.IconButton(
-            _highlightSyntax ? FontAwesomeHelper.IconCheck : FontAwesomeHelper.IconXmark,
-            "Syntax Highlighting (not currently available)"))
+        if (ImGuiUtils.IconButton(_highlightSyntax ? FontAwesomeHelper.IconCheck : FontAwesomeHelper.IconXmark, "Syntax Highlighting"))
+        {
             _highlightSyntax = !_highlightSyntax;
+            _editor.SetHighlightSyntax(_highlightSyntax);
+        }
 
         if (macro is ConfigMacro { IsGitMacro: true } configMacro)
         {
@@ -147,67 +153,14 @@ public class MacroEditor(IMacroScheduler scheduler, GitMacroManager gitManager, 
 
     private void DrawCodeEditor(IMacro macro, float height)
     {
-        var lineNumberWidth = CalculateLineNumberWidth(macro.Content);
-        var lineHeight = ImGui.GetTextLineHeight();
-        var editorPadding = 5.0f;
-
-        // Use a single scrollable child window that contains both line numbers and text editor
-        using var scrollableChild = ImRaii.Child("CodeEditorScrollable", new Vector2(0, height), false, ImGuiWindowFlags.HorizontalScrollbar);
-        if (!scrollableChild) return;
-
-        if (_showLineNumbers)
-        {
-            DrawLineNumbers(macro.Content, lineNumberWidth, lineHeight, editorPadding);
-            ImGui.SameLine(0, 0);
-        }
-
-        DrawTextEditor(macro, lineHeight, editorPadding);
-    }
-
-    private float CalculateLineNumberWidth(string content) => content.Split('\n').Length switch
-    {
-        > 999 => 60,
-        > 99 => 50,
-        _ => 40
-    };
-
-    private void DrawLineNumbers(string content, float width, float height, float padding)
-    {
-        using var _ = ImRaii.PushColor(ImGuiCol.ChildBg, new Vector4(0.1f, 0.1f, 0.1f, 1.0f)).Push(ImGuiCol.Text, ImGuiColors.DalamudGrey);
-        using var __ = ImRaii.PushStyle(ImGuiStyleVar.ItemSpacing, new Vector2(0, 0)).Push(ImGuiStyleVar.WindowPadding, new Vector2(padding, padding));
-
-        var lines = content.Split('\n');
-        var calculatedHeight = lines.Length * height + padding * 2;
-        var availableHeight = ImGui.GetContentRegionAvail().Y;
-        var totalHeight = Math.Max(calculatedHeight, availableHeight);
-
-        // Create a child window for line numbers that doesn't scroll independently
-        using var child = ImRaii.Child("LineNumbers", new Vector2(width, totalHeight), true, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse);
-        if (!child) return;
-
-        for (var i = 0; i < lines.Length; i++)
-        {
-            var textWidth = ImGui.CalcTextSize($"{i + 1}").X;
-            ImGui.SetCursorPosX(width - textWidth - 6);
-            ImGui.Text($"{i + 1}");
-        }
-    }
-
-    private void DrawTextEditor(IMacro macro, float height, float padding)
-    {
-        using var _ = ImRaii.PushColor(ImGuiCol.FrameBg, new Vector4(0.15f, 0.15f, 0.15f, 1.0f));
-        using var __ = ImRaii.PushStyle(ImGuiStyleVar.FramePadding, new Vector2(5, padding));
-
-        var lines = macro.Content.Split('\n');
-        var totalHeight = Math.Max(lines.Length * height + padding * 2, ImGui.GetContentRegionAvail().Y);
-        var editorWidth = ImGui.GetContentRegionAvail().X;
+        using var editorWrapper = ImRaii.Child("CodeEditor", new Vector2(0, height), false);
+        if (!editorWrapper) return;
 
         if (macro is ConfigMacro configMacro)
         {
-            var contents = configMacro.Content;
-            if (ImGui.InputTextMultiline("##MacroEditor", ref contents, 1_000_000, new Vector2(editorWidth, totalHeight), ImGuiInputTextFlags.AllowTabInput))
+            if (_editor.Draw())
             {
-                configMacro.Content = contents;
+                configMacro.Content = _editor.GetContent();
                 C.Save();
             }
         }

--- a/SomethingNeedDoing/SomethingNeedDoing.csproj
+++ b/SomethingNeedDoing/SomethingNeedDoing.csproj
@@ -10,6 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="ImGuiColorTextEditNetDalamud" Version="0.2.0" />
 		<PackageReference Include="Laylua" Version="1.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
 		<PackageReference Include="NLua" Version="1.7.5" />

--- a/SomethingNeedDoing/packages.lock.json
+++ b/SomethingNeedDoing/packages.lock.json
@@ -14,6 +14,12 @@
         "resolved": "1.2.25",
         "contentHash": "xCXiw7BCxHJ8pF6wPepRUddlh2dlQlbr81gXA72hdk4FLHkKXas7EH/n+fk5UCA/YfMqG1Z6XaPiUjDbUNBUzg=="
       },
+      "ImGuiColorTextEditNetDalamud": {
+        "type": "Direct",
+        "requested": "[0.2.0, )",
+        "resolved": "0.2.0",
+        "contentHash": "Frme1qDGRlyJTyM/hot4ZsguMAfjSOs7EoV0QAI2YaZFmkoStUJMSfIAUKZCuxloU4pNlqDPUU1wKBLSphV6lg=="
+      },
       "Laylua": {
         "type": "Direct",
         "requested": "[1.0.0, )",


### PR DESCRIPTION
Make use of https://github.com/OhKannaDuh/ImGuiColorTextEditNetDalamud / https://www.nuget.org/packages/ImGuiColorTextEditNetDalamud/0.2.0

# Features

- Syntax Highlighting
![image](https://github.com/user-attachments/assets/47abc1da-fa93-4047-ba27-b8cfdd779737)

- Syntax Highlighting Toggle (If you're so inclined 🤮)
![image](https://github.com/user-attachments/assets/fa42a5d5-44db-4ae4-b573-489ecb332d03)

- Tokenizer for highlighting Native Macros (Not just Lua!)
![image](https://github.com/user-attachments/assets/948c35b6-5778-48b3-a788-0912ae0754f3)

---

Might be worth having @Brappp do theming on this one 🙏 
