### PR TITLE
Advanced stub generation

### DIFF
--- a/SomethingNeedDoing/Documentation/StubGenerators/Builders/AliasBuilder.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/Builders/AliasBuilder.cs
@@ -6,44 +6,4 @@ public static class AliasBuilder
     {
         return builder.AddLine("alias", original, alias);
     }
-
-    public static Builder AddAlias<T>(this Builder builder)
-        where T : Enum
-    {
-        var enumType = typeof(T);
-
-        var names = Enum.GetNames(enumType);
-        var values = Enum.GetValues(enumType);
-
-        // Helper docs
-        builder.AddLine($"-- Usage:");
-        builder.AddLine($"-- luanet.load_assembly('{enumType.Assembly.GetName().Name ?? "UnknownAssembly"}')");
-        builder.AddLine($"-- {enumType.Name} = luanet.import_type('{enumType.FullName ?? enumType.Name}')");
-
-        var firstName = names.Length > 0 ? names[0] : string.Empty;
-        if (!string.IsNullOrEmpty(firstName))
-        {
-            builder.AddLine($"-- {enumType.Name}.{firstName}");
-        }
-
-        builder.AddLine("");
-
-        // Alias for numeric values
-        builder.AddLine($"--- @alias {enumType.Name}Value");
-        for (int i = 0; i < names.Length; i++)
-        {
-            var numericValue = Convert.ChangeType(values.GetValue(i), Enum.GetUnderlyingType(enumType));
-            builder.AddLine($"---| {numericValue} # {names[i]}");
-        }
-        builder.AddLine("");
-
-        // Generate the table-like class definition for enum members
-        builder.AddLine($"--- @class {enumType.Name}");
-        foreach (var name in names)
-        {
-            builder.AddLine($"--- @field {name} {enumType.Name}Value");
-        }
-
-        return builder;
-    }
 }

--- a/SomethingNeedDoing/Documentation/StubGenerators/Builders/AliasBuilder.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/Builders/AliasBuilder.cs
@@ -1,0 +1,49 @@
+namespace SomethingNeedDoing.Documentation.StubGenerators.Builders;
+
+public static class AliasBuilder
+{
+    public static Builder AddAlias(this Builder builder, string original, string alias)
+    {
+        return builder.AddLine("alias", original, alias);
+    }
+
+    public static Builder AddAlias<T>(this Builder builder)
+        where T : Enum
+    {
+        var enumType = typeof(T);
+
+        var names = Enum.GetNames(enumType);
+        var values = Enum.GetValues(enumType);
+
+        // Helper docs
+        builder.AddLine($"-- Usage:");
+        builder.AddLine($"-- luanet.load_assembly('{enumType.Assembly.GetName().Name ?? "UnknownAssembly"}')");
+        builder.AddLine($"-- {enumType.Name} = luanet.import_type('{enumType.FullName ?? enumType.Name}')");
+
+        var firstName = names.Length > 0 ? names[0] : string.Empty;
+        if (!string.IsNullOrEmpty(firstName))
+        {
+            builder.AddLine($"-- {enumType.Name}.{firstName}");
+        }
+
+        builder.AddLine("");
+
+        // Alias for numeric values
+        builder.AddLine($"--- @alias {enumType.Name}Value");
+        for (int i = 0; i < names.Length; i++)
+        {
+            var numericValue = Convert.ChangeType(values.GetValue(i), Enum.GetUnderlyingType(enumType));
+            builder.AddLine($"---| {numericValue} # {names[i]}");
+        }
+        builder.AddLine("");
+
+        // Generate the table-like class definition for enum members
+        builder.AddLine($"--- @class {enumType.Name}");
+        foreach (var name in names)
+        {
+            builder.AddLine($"--- @field {name} {enumType.Name}Value");
+        }
+
+        return builder;
+    }
+}

--- a/SomethingNeedDoing/Documentation/StubGenerators/Builders/Builder.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/Builders/Builder.cs
@@ -1,0 +1,32 @@
+using System.Text;
+
+namespace SomethingNeedDoing.Documentation.StubGenerators.Builders;
+
+public class Builder
+{
+    protected string LineTemplate = "--- @[type] [arg1] [arg2]";
+
+    protected StringBuilder sb = new();
+
+    public Builder AddLine(string line)
+    {
+        sb.AppendLine(line.Trim());
+        return this;
+    }
+
+    public Builder AddLine(string type, string arg1) => AddLine(type, arg1, string.Empty);
+
+    public Builder AddLine(string type, string arg1, string arg2)
+    {
+        var line = LineTemplate
+            .Replace("[type]", type)
+            .Replace("[arg1]", arg1)
+            .Replace("[arg2]", arg2);
+
+        sb.AppendLine(line.Trim());
+
+        return this;
+    }
+
+    public override string ToString() => sb.ToString();
+}

--- a/SomethingNeedDoing/Documentation/StubGenerators/Builders/ClassBuilder.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/Builders/ClassBuilder.cs
@@ -1,0 +1,14 @@
+namespace SomethingNeedDoing.Documentation.StubGenerators.Builders;
+
+public static class ClassBuilder
+{
+    public static Builder AddClass(this Builder builder, string name)
+    {
+        return builder.AddLine("class", name);
+    }
+
+    public static Builder AddField(this Builder builder, string name, string type)
+    {
+        return builder.AddLine("field", name, type);
+    }
+}

--- a/SomethingNeedDoing/Documentation/StubGenerators/Builders/EnumBuilder.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/Builders/EnumBuilder.cs
@@ -1,0 +1,44 @@
+namespace SomethingNeedDoing.Documentation.StubGenerators.Builders;
+
+public static class EnumBuilder
+{
+    public static Builder AddEnum(this Builder builder, Type enumType)
+    {
+        if (!enumType.IsEnum)
+            throw new ArgumentException("Provided type must be an enum.", nameof(enumType));
+
+        var names = Enum.GetNames(enumType);
+        var values = Enum.GetValues(enumType);
+
+        // Helper docs
+        builder.AddLine($"-- Usage:");
+        builder.AddLine($"-- luanet.load_assembly('{enumType.Assembly.GetName().Name ?? "UnknownAssembly"}')");
+        builder.AddLine($"-- {enumType.Name} = luanet.import_type('{enumType.FullName ?? enumType.Name}')");
+
+        var firstName = names.Length > 0 ? names[0] : string.Empty;
+        if (!string.IsNullOrEmpty(firstName))
+        {
+            builder.AddLine($"-- {enumType.Name}.{firstName}");
+        }
+
+        builder.AddLine("");
+
+        // Alias for numeric values
+        builder.AddLine("alias", $"{enumType.Name}Value");
+        for (int i = 0; i < names.Length; i++)
+        {
+            var numericValue = Convert.ChangeType(values.GetValue(i), Enum.GetUnderlyingType(enumType));
+            builder.AddLine($"---| {numericValue} # {names[i]}");
+        }
+        builder.AddLine("");
+
+        // Generate the table-like class definition for enum members
+        builder.AddClass(enumType.Name);
+        foreach (var name in names)
+        {
+            builder.AddField(name, $"{enumType.Name}Value");
+        }
+
+        return builder;
+    }
+}

--- a/SomethingNeedDoing/Documentation/StubGenerators/Builders/FunctionBuilder.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/Builders/FunctionBuilder.cs
@@ -1,0 +1,26 @@
+namespace SomethingNeedDoing.Documentation.StubGenerators.Builders;
+
+public static class FunctionBuilder
+{
+    public static Builder AddParam(this Builder builder, string name, string type)
+    {
+        return builder.AddLine($"--- @param {name} {type}");
+    }
+
+    public static Builder AddReturn(this Builder builder, string type)
+    {
+        return builder.AddLine($"--- @return {type}");
+    }
+
+    public static Builder AddFunction(this Builder builder, string name, (string name, string type)[] parameters, string returnType)
+    {
+        foreach (var (paramName, paramType) in parameters)
+            builder.AddParam(paramName, paramType);
+
+        builder.AddReturn(returnType);
+        var paramList = string.Join(", ", parameters.Select(p => p.name));
+        builder.AddLine($"function {name}({paramList}) end");
+
+        return builder;
+    }
+}

--- a/SomethingNeedDoing/Documentation/StubGenerators/ClassStubGenerator .cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/ClassStubGenerator .cs
@@ -1,0 +1,91 @@
+
+using SomethingNeedDoing.Documentation.StubGenerators.Builders;
+using System.Reflection;
+
+namespace SomethingNeedDoing.Documentation.StubGenerators;
+
+internal sealed class ClassStubGenerator(Type type) : StubGenerator
+{
+    private readonly Type _type = type ?? throw new ArgumentNullException(nameof(type));
+
+    protected override StubFile GenerateStub()
+    {
+        var filename = ToSnakeCase(_type.Name);
+        var file = new StubFile("classes", $"{filename}.lua");
+        var builder = new Builder();
+
+        builder.AddLine($"--- @class {_type.Name}");
+
+        // Properties
+        var properties = _type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.GetIndexParameters().Length == 0); // Skip indexers
+
+        foreach (var prop in properties)
+        {
+            var luaType = LuaTypeConverter.GetLuaType(prop.PropertyType);
+            builder.AddLine($"--- @field {prop.Name} {luaType}");
+        }
+
+        // Fields
+        var fields = _type.GetFields(BindingFlags.Public | BindingFlags.Instance);
+        foreach (var field in fields)
+        {
+            var luaType = LuaTypeConverter.GetLuaType(field.FieldType);
+            builder.AddLine($"--- @field {field.Name} {luaType}");
+        }
+
+        // Methods
+        var methods = _type.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(IsLuaRelevantMethod)
+            .Where(m => !m.IsSpecialName && m.DeclaringType == _type); // Exclude property accessors and inherited .NET object methods
+
+        foreach (var method in methods)
+        {
+            var parameters = method.GetParameters()
+                .Select(p => $"{p.Name}: {LuaTypeConverter.GetLuaType(p.ParameterType)}");
+
+            var returnType = LuaTypeConverter.GetLuaType(method.ReturnType);
+            builder.AddLine($"--- @field {method.Name} fun({string.Join(", ", parameters)}): {returnType}");
+        }
+
+        var ctor = _type.GetConstructors(BindingFlags.Public | BindingFlags.Instance)
+        .OrderByDescending(c => c.GetParameters().Length)
+        .FirstOrDefault();
+
+        if (ctor != null)
+        {
+            builder.AddLine("");
+
+            var parameters = ctor.GetParameters()
+                .Select(p => $"{p.Name} {LuaTypeConverter.GetLuaType(p.ParameterType)}");
+
+            var args = ctor.GetParameters()
+                .Select(p => $"{p.Name}");
+
+            foreach (var param in parameters)
+            {
+                builder.AddLine($"--- @param {param}");
+            }
+
+            builder.AddLine($"--- @return {_type.Name}");
+
+            builder.AddLine($"function {_type.Name}({string.Join(", ", args)}) end");
+        }
+
+        file.AddBuilder(builder);
+        return file;
+    }
+
+    private static bool IsLuaRelevantMethod(MethodInfo method)
+    {
+        var name = method.Name;
+        if (name is "GetHashCode" or "Equals" or "CopyTo" or "TryCopyTo")
+            return false;
+
+        // Remove ToString overloads with format/provider
+        if (name == "ToString" && method.GetParameters().Length > 0)
+            return false;
+
+        return true;
+    }
+}

--- a/SomethingNeedDoing/Documentation/StubGenerators/ComplexTypeStubGenerator.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/ComplexTypeStubGenerator.cs
@@ -1,0 +1,122 @@
+using SomethingNeedDoing.Documentation.StubGenerators.Builders;
+using System.Reflection;
+
+namespace SomethingNeedDoing.Documentation.StubGenerators;
+
+internal sealed class ComplexTypeStubGenerator(Type type) : StubGenerator
+{
+    // Static list of generated types to prevent infinite recursion
+    private static readonly HashSet<Type> GeneratedTypes = [];
+
+    // White list for base namespace component before recursivley including a type
+    private readonly HashSet<string> NamespaceWhitelist = [
+        "Dalamud",
+        "ECommons",
+        "FFXIVClientStructs",
+        "Lumina"
+    ];
+
+    // Blacklist for types to not include, i.e. not including address pointers
+    private static readonly HashSet<Type> ExcludedTypes = [
+        typeof(IntPtr),
+        typeof(UIntPtr),
+        typeof(void*),
+        typeof(byte*),
+        typeof(void),
+    ];
+
+    private readonly Type _type = type;
+
+    protected override StubFile GenerateStub()
+    {
+        GeneratedTypes.Add(_type);
+
+        var file = new StubFile("classes", $"{ToSnakeCase(_type.Name)}.lua");
+        var builder = new Builder();
+
+        builder.AddLine($"-- FQN: {_type.FullName}");
+        builder.AddLine("");
+
+        builder.AddLine($"--- @class {_type.Name}");
+
+        foreach (var prop in GetAllProperties(_type))
+        {
+            if (!ShouldIncludeProperty(prop))
+                continue;
+
+            var fieldName = prop.Name;
+            builder.AddLine($"--- @field {fieldName} {GetPropertyType(prop)}");
+
+            if (prop.PropertyType.IsEnum)
+            {
+                new EnumStubGenerator(prop.PropertyType).GetStubFile().Write();
+            }
+
+            if (!GeneratedTypes.Contains(prop.PropertyType) && !ShouldIgnoreForStub(prop.PropertyType))
+            {
+                GeneratedTypes.Add(prop.PropertyType); // To prevent infinite recursion
+                new ComplexTypeStubGenerator(prop.PropertyType).GetStubFile().Write();
+            }
+        }
+
+        builder.AddLine("");
+        builder.AddLine($"--- @type {_type.Name}");
+        builder.AddLine($"--- @as {_type.Name}");
+        builder.AddLine($"{_type.Name} = {{}}");
+
+        file.AddBuilder(builder);
+        return file;
+    }
+
+    private IEnumerable<PropertyInfo> GetAllProperties(Type type)
+    {
+        if (type.IsInterface)
+        {
+            return type.GetProperties()
+                .Concat(type.GetInterfaces().SelectMany(i => i.GetProperties()))
+                .Distinct();
+        }
+        else
+        {
+            return type.GetProperties(BindingFlags.Public | BindingFlags.Static);
+        }
+    }
+
+    private string GetPropertyType(PropertyInfo prop)
+    {
+        var type = LuaTypeConverter.GetLuaType(prop.PropertyType).TypeName;
+
+        return type == "object" ? prop.PropertyType.Name : type;
+    }
+
+    private bool ShouldIncludeProperty(PropertyInfo prop)
+    {
+        if (prop.GetIndexParameters().Length > 0)
+            return false;
+
+        var type = prop.PropertyType;
+
+        if (ExcludedTypes.Contains(type))
+            return false;
+
+        if (type.IsPrimitive || type.IsEnum)
+            return true;
+
+        return !ShouldIgnoreForStub(type);
+    }
+
+    private bool ShouldIgnoreForStub(Type type)
+    {
+        if (type.IsPrimitive || type.IsPointer)
+            return true;
+
+        if (type.IsGenericType || type.IsGenericTypeDefinition)
+            return true;
+
+        var ns = type.Namespace;
+        if (string.IsNullOrEmpty(ns))
+            return true;
+
+        return !NamespaceWhitelist.Any(allowed => ns.StartsWith(allowed, StringComparison.Ordinal));
+    }
+}

--- a/SomethingNeedDoing/Documentation/StubGenerators/EnumStubGenerator.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/EnumStubGenerator.cs
@@ -1,16 +1,26 @@
+using SomethingNeedDoing.Documentation.StubGenerators;
 using SomethingNeedDoing.Documentation.StubGenerators.Builders;
 
-namespace SomethingNeedDoing.Documentation.StubGenerators;
-
-internal sealed class EnumStubGenerator<T> : StubGenerator
-    where T : Enum
+internal sealed class EnumStubGenerator : StubGenerator
 {
-    public override StubFile GenerateStub(IEnumerable<Type> _)
+    private readonly Type _enumType;
+
+    public EnumStubGenerator(Type enumType)
     {
-        var filename = ToSnakeCase(typeof(T).Name);
+        if (!enumType.IsEnum)
+        {
+            throw new ArgumentException("Type must be an enum.", nameof(enumType));
+        }
+
+        _enumType = enumType;
+    }
+
+    protected override StubFile GenerateStub()
+    {
+        var filename = ToSnakeCase(_enumType.Name);
         var file = new StubFile("enums", $"{filename}.lua");
 
-        file.AddBuilder(new Builder().AddAlias<T>());
+        file.AddBuilder(new Builder().AddEnum(_enumType));
 
         return file;
     }

--- a/SomethingNeedDoing/Documentation/StubGenerators/EnumStubGenerator.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/EnumStubGenerator.cs
@@ -1,0 +1,17 @@
+using SomethingNeedDoing.Documentation.StubGenerators.Builders;
+
+namespace SomethingNeedDoing.Documentation.StubGenerators;
+
+internal sealed class EnumStubGenerator<T> : StubGenerator
+    where T : Enum
+{
+    public override StubFile GenerateStub(IEnumerable<Type> _)
+    {
+        var filename = ToSnakeCase(typeof(T).Name);
+        var file = new StubFile("enums", $"{filename}.lua");
+
+        file.AddBuilder(new Builder().AddAlias<T>());
+
+        return file;
+    }
+}

--- a/SomethingNeedDoing/Documentation/StubGenerators/GlobalStubGenerator.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/GlobalStubGenerator.cs
@@ -4,11 +4,38 @@ namespace SomethingNeedDoing.Documentation.StubGenerators;
 
 internal sealed class GlobalStubGenerator : StubGenerator
 {
-    public override StubFile GenerateStub(IEnumerable<Type> _)
+    protected override StubFile GenerateStub()
     {
         var file = new StubFile("global.lua");
 
         file.AddBuilder(new Builder().AddAlias("object", "any"));
+
+        file.AddBuilder(new Builder().AddFunction("yield", [("value", "string")], "nil"));
+
+        // NLua
+        file.AddBuilder(new Builder().AddFunction("import", [("assemblyName", "string"), ("packageName", "string?")], "table"));
+        file.AddBuilder(new Builder().AddFunction("CLRPackage", [("assemblyName", "string"), ("packageName", "string?")], "table"));
+
+        // Luanet
+        file.AddBuilder(
+            new Builder()
+                .AddClass("Luanet")
+                .AddField("load_assembly", "fun(assemblyName: string): boolean")
+                .AddField("import_type", "fun(typename: string): boolean")
+                .AddField("namespace", "fun(ns: string|string[]|table<string>): boolean")
+                .AddField("make_array", "fun(type: object, from: table): object[]")
+                .AddField("each", "fun(source: object[]|table): fun(): object")
+                .AddField("enum", "fun(enumType: string): table<string, integer>")
+                .AddField("enum", "fun(enumType: object, value: string|integer): object")
+                .AddField("ctype", "fun(proxy: object): object")
+                .AddField("make_object", "fun(methodTable: table, className: string): object")
+                .AddField("free_object", "fun(obj: object): nil")
+                .AddField("get_object_member", "fun(obj: object, member: string|integer): object")
+                .AddLine("")
+                .AddLine("--- @type Luanet")
+                .AddLine("--- @as Luanet")
+                .AddLine("luanet = {}")
+        );
 
         return file;
     }

--- a/SomethingNeedDoing/Documentation/StubGenerators/GlobalStubGenerator.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/GlobalStubGenerator.cs
@@ -1,0 +1,15 @@
+using SomethingNeedDoing.Documentation.StubGenerators.Builders;
+
+namespace SomethingNeedDoing.Documentation.StubGenerators;
+
+internal sealed class GlobalStubGenerator : StubGenerator
+{
+    public override StubFile GenerateStub(IEnumerable<Type> _)
+    {
+        var file = new StubFile("global.lua");
+
+        file.AddBuilder(new Builder().AddAlias("object", "any"));
+
+        return file;
+    }
+}

--- a/SomethingNeedDoing/Documentation/StubGenerators/IPCStubGenerator.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/IPCStubGenerator.cs
@@ -1,0 +1,69 @@
+using SomethingNeedDoing.Documentation.StubGenerators.Builders;
+
+namespace SomethingNeedDoing.Documentation.StubGenerators;
+
+internal sealed class IpcStubGenerator(LuaDocumentation luaDocs) : StubGenerator
+{
+    private readonly LuaDocumentation _luaDocs = luaDocs ?? throw new ArgumentNullException(nameof(luaDocs));
+
+    protected override StubFile GenerateStub()
+    {
+        var file = new StubFile("modules", "ipc.lua");
+        var ipcModules = _luaDocs.GetModules()
+            .Where(m => m.Key == "IPC")
+            .ToList();
+
+        if (ipcModules.Count == 0)
+            return file;
+
+        var ipcEntries = ipcModules[0].Value;
+
+        var grouped = ipcEntries
+            .GroupBy(f => f.ModuleName.Contains('.') ? f.ModuleName.Split('.')[1] : "Root")
+            .ToList();
+
+        var groupNames = new List<string>();
+
+        // Generate class stubs for each IPC sub-group
+        foreach (var group in grouped)
+        {
+            var className = group.Key;
+            groupNames.Add(className);
+
+            var classBuilder = new Builder();
+            classBuilder.AddLine($"--- @class {className}");
+
+            foreach (var doc in group)
+            {
+                var type = doc.IsMethod ? GetLuaFunctionSignature(doc) : doc.ReturnType.ToString();
+                classBuilder.AddLine($"--- @field {doc.FunctionName} {type}");
+            }
+
+            file.AddBuilder(classBuilder);
+        }
+
+        // Generate root IPC class
+        var ipcBuilder = new Builder();
+        ipcBuilder.AddLine($"--- @class IPC");
+
+        foreach (var name in groupNames)
+            ipcBuilder.AddLine($"--- @field {name} {name}");
+
+        ipcBuilder.AddLine("");
+        ipcBuilder.AddLine($"--- @type IPC");
+        ipcBuilder.AddLine($"--- @as IPC");
+        ipcBuilder.AddLine("IPC = {}");
+
+        file.AddBuilder(ipcBuilder);
+
+        return file;
+    }
+
+    private static string GetLuaFunctionSignature(LuaFunctionDoc doc)
+    {
+        var parameters = doc.Parameters != null && doc.Parameters.Any()
+            ? string.Join(", ", doc.Parameters.Select(p => $"{p.Name}: {p.Type}"))
+            : "";
+        return $"fun({parameters}): {doc.ReturnType}";
+    }
+}

--- a/SomethingNeedDoing/Documentation/StubGenerators/ModuleStubGenerator.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/ModuleStubGenerator.cs
@@ -1,0 +1,42 @@
+using SomethingNeedDoing.Documentation.StubGenerators.Builders;
+
+namespace SomethingNeedDoing.Documentation.StubGenerators;
+
+internal sealed class ModuleStubGenerator(string moduleName, IReadOnlyList<LuaFunctionDoc> entries) : StubGenerator
+{
+    private readonly string _moduleName = moduleName ?? throw new ArgumentNullException(nameof(moduleName));
+
+    private readonly IReadOnlyList<LuaFunctionDoc> _entries = entries ?? throw new ArgumentNullException(nameof(entries));
+
+    protected override StubFile GenerateStub()
+    {
+        var filename = ToSnakeCase(_moduleName);
+        var file = new StubFile("modules", $"{filename}.lua");
+        var builder = new Builder();
+
+        builder.AddLine($"--- @class {_moduleName}");
+
+        foreach (var doc in _entries)
+        {
+            var type = doc.IsMethod
+                ? GetLuaFunctionSignature(doc)
+                : doc.ReturnType.ToString();
+
+            builder.AddLine($"--- @field {doc.FunctionName} {type}");
+        }
+
+        builder.AddLine("");
+        builder.AddLine($"--- @type {_moduleName}");
+        builder.AddLine($"--- @as {_moduleName}");
+        builder.AddLine($"{_moduleName} = {{}}");
+
+        file.AddBuilder(builder);
+        return file;
+    }
+
+    private string GetLuaFunctionSignature(LuaFunctionDoc doc)
+    {
+        var parameters = doc.Parameters != null && doc.Parameters.Any() ? string.Join(", ", doc.Parameters.Select(p => $"{p.Name}: {p.Type}")) : "";
+        return $"fun({parameters}): {doc.ReturnType}";
+    }
+}

--- a/SomethingNeedDoing/Documentation/StubGenerators/StubFile.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/StubFile.cs
@@ -1,5 +1,4 @@
 using SomethingNeedDoing.Documentation.StubGenerators.Builders;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
@@ -22,6 +21,8 @@ internal sealed class StubFile
 
     public void AddBuilder(Builder builder) => builders.Add(builder);
 
+    public void PrependBuilder(Builder builder) => builders.Insert(0, builder);
+
     public void Write()
     {
         var path = GetStubPath(pathParts);
@@ -43,6 +44,6 @@ internal sealed class StubFile
 
     private static string GetStubPath(string[] parts)
     {
-        return Path.Combine(Svc.PluginInterface.ConfigDirectory.FullName, Path.Combine(parts));
+        return Path.Combine(Svc.PluginInterface.ConfigDirectory.FullName, "stubs", Path.Combine(parts));
     }
 }

--- a/SomethingNeedDoing/Documentation/StubGenerators/StubFile.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/StubFile.cs
@@ -1,0 +1,48 @@
+using SomethingNeedDoing.Documentation.StubGenerators.Builders;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace SomethingNeedDoing.Documentation.StubGenerators;
+
+internal sealed class StubFile
+{
+    private readonly string[] pathParts;
+    private readonly List<Builder> builders = [];
+
+    public StubFile(params string[] pathParts)
+    {
+        if (pathParts == null || pathParts.Length == 0)
+        {
+            throw new ArgumentException("Must provide at least one path part", nameof(pathParts));
+        }
+
+        this.pathParts = pathParts;
+    }
+
+    public void AddBuilder(Builder builder) => builders.Add(builder);
+
+    public void Write()
+    {
+        var path = GetStubPath(pathParts);
+
+        var sb = new StringBuilder();
+        for (int i = 0; i < builders.Count; i++)
+        {
+            sb.Append(builders[i].ToString());
+
+            if (i != builders.Count - 1)
+            {
+                sb.AppendLine();
+            }
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, sb.ToString());
+    }
+
+    private static string GetStubPath(string[] parts)
+    {
+        return Path.Combine(Svc.PluginInterface.ConfigDirectory.FullName, Path.Combine(parts));
+    }
+}

--- a/SomethingNeedDoing/Documentation/StubGenerators/StubGenerator.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/StubGenerator.cs
@@ -1,3 +1,4 @@
+using SomethingNeedDoing.Documentation.StubGenerators.Builders;
 using System.IO;
 using System.Text;
 
@@ -5,7 +6,27 @@ namespace SomethingNeedDoing.Documentation.StubGenerators;
 
 internal abstract class StubGenerator
 {
-    public abstract StubFile GenerateStub(IEnumerable<Type> registry);
+    private readonly List<string> documentation = [];
+
+    protected abstract StubFile GenerateStub();
+
+    public StubFile GetStubFile()
+    {
+        var stub = GenerateStub();
+
+        if (documentation.Count > 0)
+        {
+            var builder = new Builder();
+            foreach (var line in documentation)
+            {
+                builder.AddLine($"-- {line}");
+            }
+
+            stub.PrependBuilder(builder);
+        }
+
+        return stub;
+    }
 
     protected string GetStubPath(string filename) => Path.Combine(Svc.PluginInterface.ConfigDirectory.FullName, "stubs", filename);
 
@@ -15,6 +36,12 @@ internal abstract class StubGenerator
         var allSegments = new List<string> { baseDir, "stubs" };
         allSegments.AddRange(pathSegments);
         return Path.Combine([.. allSegments]);
+    }
+
+    public StubGenerator WithDocumentationLine(string line)
+    {
+        documentation.Add(line);
+        return this;
     }
 
     protected string ToSnakeCase(string input)

--- a/SomethingNeedDoing/Documentation/StubGenerators/StubGenerator.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/StubGenerator.cs
@@ -1,0 +1,48 @@
+using System.IO;
+using System.Text;
+
+namespace SomethingNeedDoing.Documentation.StubGenerators;
+
+internal abstract class StubGenerator
+{
+    public abstract StubFile GenerateStub(IEnumerable<Type> registry);
+
+    protected string GetStubPath(string filename) => Path.Combine(Svc.PluginInterface.ConfigDirectory.FullName, "stubs", filename);
+
+    protected string GetStubPath(params string[] pathSegments)
+    {
+        var baseDir = Svc.PluginInterface.ConfigDirectory.FullName;
+        var allSegments = new List<string> { baseDir, "stubs" };
+        allSegments.AddRange(pathSegments);
+        return Path.Combine([.. allSegments]);
+    }
+
+    protected string ToSnakeCase(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return input;
+        }
+
+        var sb = new StringBuilder();
+        for (int i = 0; i < input.Length; i++)
+        {
+            var c = input[i];
+            if (char.IsUpper(c))
+            {
+                if (i > 0)
+                {
+                    sb.Append('_');
+                }
+
+                sb.Append(char.ToLower(c));
+            }
+            else
+            {
+                sb.Append(c);
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/SomethingNeedDoing/Documentation/StubGenerators/ToDo.MD
+++ b/SomethingNeedDoing/Documentation/StubGenerators/ToDo.MD
@@ -1,6 +1,0 @@
-# Test I can load stubs that sit underneath classes this way:
-
--- Usage:
--- luanet.load_assembly('SomethingNeedDoing')
--- FateRule = luanet.import_type('SomethingNeedDoing.LuaMacro.Modules.FateModule+FateRule')
--- FateRule.None

--- a/SomethingNeedDoing/Documentation/StubGenerators/ToDo.MD
+++ b/SomethingNeedDoing/Documentation/StubGenerators/ToDo.MD
@@ -1,0 +1,6 @@
+# Test I can load stubs that sit underneath classes this way:
+
+-- Usage:
+-- luanet.load_assembly('SomethingNeedDoing')
+-- FateRule = luanet.import_type('SomethingNeedDoing.LuaMacro.Modules.FateModule+FateRule')
+-- FateRule.None

--- a/SomethingNeedDoing/Documentation/StubGenerators/WrapperStubGenerator.cs
+++ b/SomethingNeedDoing/Documentation/StubGenerators/WrapperStubGenerator.cs
@@ -1,0 +1,46 @@
+using SomethingNeedDoing.Documentation;
+using SomethingNeedDoing.Documentation.StubGenerators;
+using SomethingNeedDoing.Documentation.StubGenerators.Builders;
+using System.Reflection;
+
+internal sealed class WrapperStubGenerator(Type wrapperType) : StubGenerator
+{
+    private readonly Type _wrapperType = wrapperType ?? throw new ArgumentNullException(nameof(wrapperType));
+
+    protected override StubFile GenerateStub()
+    {
+        var filename = ToSnakeCase(_wrapperType.Name);
+        var file = new StubFile("wrappers", $"{filename}.lua");
+        var builder = new Builder();
+
+        builder.AddLine($"--- @class {_wrapperType.Name}");
+
+        var properties = _wrapperType
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.GetCustomAttributes(typeof(LuaDocsAttribute), true).Length != 0);
+
+        foreach (var prop in properties)
+        {
+            if (prop.Name == "Item" && prop.GetIndexParameters().Length > 0) continue;
+
+            var typeName = LuaTypeConverter.GetLuaType(prop.PropertyType);
+            builder.AddLine($"--- @field {prop.Name} {typeName}");
+        }
+
+        var methods = _wrapperType
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(m => m.GetCustomAttributes(typeof(LuaDocsAttribute), true).Length != 0);
+
+        foreach (var method in methods)
+        {
+            var parameters = method.GetParameters()
+                .Select(p => $"{p.Name}: {LuaTypeConverter.GetLuaType(p.ParameterType)}");
+            var returnType = LuaTypeConverter.GetLuaType(method.ReturnType);
+
+            builder.AddLine($"--- @field {method.Name} fun({string.Join(", ", parameters)}): {returnType}");
+        }
+
+        file.AddBuilder(builder);
+        return file;
+    }
+}


### PR DESCRIPTION
The goal here was to clean up the stub generation process massively, and make it easier to expand in the future.

The service class is now much leaner and is really only no longer produces any stubs directly itself, that's all been abstracted to other classes.

Stubs also get stored in unique files, again this is for maintainability and finding issues in generated stubs.
![image](https://github.com/user-attachments/assets/5606a09e-343c-40ba-9daf-9e56906be5f1)

Class stubs and Enums tubs both include their FQ name:
```lua
-- FQN: Dalamud.Game.ClientState.Objects.SubKinds.IPlayerCharacter

--- @class IPlayerCharacter
--- @field StatusList StatusList
--- @field IsCasting boolean
--- @field IsCastInterruptible boolean
--- @field CastActionType number
--- @field CastActionId number
--- @field CastTargetObjectId number
--- @field CurrentCastTime number
--- @field BaseCastTime number
--- @field TotalCastTime number
--- @field CurrentHp number
--- @field MaxHp number
--- @field CurrentMp number
--- @field MaxMp number
--- @field CurrentGp number
--- @field MaxGp number
--- @field CurrentCp number
--- @field MaxCp number
--- @field ShieldPercentage number
--- @field Level number
--- @field CompanyTag SeString
--- @field NameId number
--- @field StatusFlags StatusFlags
--- @field Name SeString
--- @field GameObjectId number
--- @field EntityId number
--- @field DataId number
--- @field OwnerId number
--- @field ObjectIndex number
--- @field ObjectKind ObjectKind
--- @field SubKind number
--- @field YalmDistanceX number
--- @field YalmDistanceZ number
--- @field IsDead boolean
--- @field IsTargetable boolean
--- @field Rotation number
--- @field HitboxRadius number
--- @field TargetObjectId number
--- @field TargetObject IGameObject

--- @type IPlayerCharacter
--- @as IPlayerCharacter
IPlayerCharacter = {}
```

```lua
-- Usage:
-- luanet.load_assembly('FFXIVClientStructs')
-- ItemFlags = luanet.import_type('FFXIVClientStructs.FFXIV.Client.Game.InventoryItem+ItemFlags')
-- ItemFlags.None

--- @alias ItemFlagsValue
---| 0 # None
---| 1 # HighQuality
---| 2 # CompanyCrestApplied
---| 4 # Relic
---| 8 # Collectable

--- @class ItemFlags
--- @field None ItemFlagsValue
--- @field HighQuality ItemFlagsValue
--- @field CompanyCrestApplied ItemFlagsValue
--- @field Relic ItemFlagsValue
--- @field Collectable ItemFlagsValue
```

I've chosen not to automatically created stubs for all used classes, as that'd be a nightmare. I added stubs for Vector2, 3 & 4, because they were mentioned in the Lua Type Converter.

I've created a so called `ComplexTypeStubGenerator` for recursibley registering classes and enums from a given base.
`new ComplexTypeStubGenerator(typeof(Svc)).GetStubFile().Write();`

This comes with a namespace whitelist so it only considers classes that fall under those namespaces, and a type blacklist, which right now stops pointer types from being represented in stubs.

The service also cleans up the legacy stub file and the stubs directory before generating so we don't have to worry about lose stub files