### PR TITLE
Editor bug fixes wave 2

### DIFF
--- a/SomethingNeedDoing/Gui/Editor/CodeEditor.cs
+++ b/SomethingNeedDoing/Gui/Editor/CodeEditor.cs
@@ -9,13 +9,13 @@ namespace SomethingNeedDoing.Gui.Editor;
 /// <summary>
 /// DalamudCodeEditor TextEditor wrapper.
 /// </summary>
-public class CodeEditor
+public class CodeEditor(LuaLanguageDefinition lua)
 {
     private readonly TextEditor _editor = new();
 
     private readonly Dictionary<MacroType, LanguageDefinition> _languages = new()
     {
-        { MacroType.Lua, new LuaLanguageDefinition() }, { MacroType.Native, new NativeMacroLanguageDefinition() },
+        { MacroType.Lua, lua }, { MacroType.Native, new NativeMacroLanguageDefinition() },
     };
 
     private IMacro? macro = null;

--- a/SomethingNeedDoing/Gui/Editor/CodeEditor.cs
+++ b/SomethingNeedDoing/Gui/Editor/CodeEditor.cs
@@ -24,12 +24,25 @@ public class CodeEditor
     public bool ReadOnly
     {
         get => _editor.IsReadOnly;
-        set
-        {
-            if (_editor.IsReadOnly == value)
-                return;
-            _editor.ToggleReadOnly();
-        }
+        set => _editor.SetReadOnly(value);
+    }
+
+    public bool IsHighlightingSyntax
+    {
+        get => _editor.Colorizer.Enabled;
+        set => _editor.Colorizer.SetEnabled(value);
+    }
+
+    public bool IsShowingWhitespace
+    {
+        get => _editor.Style.ShowWhitespace;
+        set => _editor.Style.SetShowWhitespace(value);
+    }
+
+    public bool IsShowingLineNumbers
+    {
+        get => _editor.Style.ShowLineNumbers;
+        set => _editor.Style.SetShowLineNumbers(value);
     }
 
     public void SetMacro(IMacro macro)
@@ -44,18 +57,6 @@ public class CodeEditor
         if (_languages.TryGetValue(macro.Type, out var language))
             _editor.Language = language;
     }
-
-    public bool IsHighlightingSyntax() => _editor.Colorizer.Enabled;
-
-    public void ToggleSyntaxHighlight() => _editor.Colorizer.Toggle();
-
-    public bool IsShowingWhitespaces() => _editor.Style.ShowWhitespace;
-
-    public void ToggleWhitespace() => _editor.Style.ToggleWhitespace();
-
-    public bool IsShowingLineNumbers() => _editor.Style.ShowLineNumbers;
-
-    public void ToggleLineNumbers() => _editor.Style.ToggleLineNumbers();
 
     public string GetContent() => _editor.Buffer.GetText();
 

--- a/SomethingNeedDoing/Gui/Editor/CodeEditor.cs
+++ b/SomethingNeedDoing/Gui/Editor/CodeEditor.cs
@@ -45,6 +45,8 @@ public class CodeEditor(LuaLanguageDefinition lua)
         set => _editor.Style.SetShowLineNumbers(value);
     }
 
+    public int Column => _editor.Cursor.GetPosition().Column;
+
     public void SetMacro(IMacro macro)
     {
         if (this.macro?.Id == macro.Id)

--- a/SomethingNeedDoing/Gui/Editor/LuaLanguageDefinition.cs
+++ b/SomethingNeedDoing/Gui/Editor/LuaLanguageDefinition.cs
@@ -1,0 +1,23 @@
+using DalamudCodeEditor;
+using SomethingNeedDoing.Documentation;
+
+namespace SomethingNeedDoing.Gui.Editor;
+
+public class LuaLanguageDefinition : DalamudCodeEditor.LuaLanguageDefinition
+{
+    public LuaLanguageDefinition(LuaDocumentation luaDocs)
+    {
+        var sndSpecificSymbols = new List<string>(["Svc", "luanet", "import", "CLRPackage", "yield"]);
+
+        // Add module keys
+        foreach (var module in luaDocs.GetModules())
+        {
+            sndSpecificSymbols.Add(module.Key);
+        }
+
+        foreach (var ident in sndSpecificSymbols)
+        {
+            Identifiers[ident] = new Identifier { Declaration = "SND" };
+        }
+    }
+}

--- a/SomethingNeedDoing/Gui/MacroEditor.cs
+++ b/SomethingNeedDoing/Gui/MacroEditor.cs
@@ -111,16 +111,16 @@ public class MacroEditor(IMacroScheduler scheduler, GitMacroManager gitManager, 
         }
 
         ImGui.SameLine();
-        if (ImGuiUtils.IconButton(_editor.IsShowingLineNumbers() ? FontAwesomeHelper.IconSortAsc : FontAwesomeHelper.IconSortDesc, "Toggle Line Numbers"))
-            _editor.ToggleLineNumbers();
+        if (ImGuiUtils.IconButton(_editor.IsShowingLineNumbers ? FontAwesomeHelper.IconSortAsc : FontAwesomeHelper.IconSortDesc, "Toggle Line Numbers"))
+            _editor.IsShowingLineNumbers ^= true;
 
         ImGui.SameLine();
-        if (ImGuiUtils.IconButton(_editor.IsShowingWhitespaces() ? FontAwesomeHelper.IconInvisible : FontAwesomeHelper.IconVisible, "Toggle Line Numbers"))
-            _editor.ToggleWhitespace();
+        if (ImGuiUtils.IconButton(_editor.IsShowingWhitespace ? FontAwesomeHelper.IconInvisible : FontAwesomeHelper.IconVisible, "Toggle Line Numbers"))
+            _editor.IsShowingWhitespace ^= true;
 
         ImGui.SameLine();
-        if (ImGuiUtils.IconButton(_editor.IsHighlightingSyntax() ? FontAwesomeHelper.IconCheck : FontAwesomeHelper.IconXmark, "Syntax Highlighting"))
-            _editor.ToggleSyntaxHighlight();
+        if (ImGuiUtils.IconButton(_editor.IsHighlightingSyntax ? FontAwesomeHelper.IconCheck : FontAwesomeHelper.IconXmark, "Syntax Highlighting"))
+            _editor.IsShowingLineNumbers ^= true;
 
         if (macro is ConfigMacro { IsGitMacro: true } configMacro)
         {

--- a/SomethingNeedDoing/Gui/MacroEditor.cs
+++ b/SomethingNeedDoing/Gui/MacroEditor.cs
@@ -119,7 +119,7 @@ public class MacroEditor(IMacroScheduler scheduler, GitMacroManager gitManager, 
 
         ImGui.SameLine();
         if (ImGuiUtils.IconButton(_editor.IsHighlightingSyntax ? FontAwesomeHelper.IconCheck : FontAwesomeHelper.IconXmark, "Syntax Highlighting"))
-            _editor.IsShowingLineNumbers ^= true;
+            _editor.IsHighlightingSyntax ^= true;
 
         if (macro is ConfigMacro { IsGitMacro: true } configMacro)
         {

--- a/SomethingNeedDoing/Gui/MacroEditor.cs
+++ b/SomethingNeedDoing/Gui/MacroEditor.cs
@@ -173,7 +173,7 @@ public class MacroEditor(IMacroScheduler scheduler, GitMacroManager gitManager, 
         using var _ = ImRaii.PushColor(ImGuiCol.FrameBg, new Vector4(0.1f, 0.1f, 0.1f, 1.0f));
 
         var chars = macro.Content.Length;
-        ImGuiEx.Text(ImGuiColors.DalamudGrey, $"Name: {macro.Name}  |  Lines: {_editor.Lines}  |  Chars: {chars}  |  Readonly: {_editor.ReadOnly}  |");
+        ImGuiEx.Text(ImGuiColors.DalamudGrey, $"Name: {macro.Name}  |  Lines: {_editor.Lines}  |  Chars: {chars}  |  Column: {_editor.Column}  |  Readonly: {_editor.ReadOnly}  |");
         ImGui.SameLine(0, 5);
         ImGuiEx.Text(ImGuiColors.DalamudGrey, $"Type: {macro.Type}");
         if (ImGui.IsItemClicked())

--- a/SomethingNeedDoing/Gui/MacroEditor.cs
+++ b/SomethingNeedDoing/Gui/MacroEditor.cs
@@ -14,12 +14,11 @@ namespace SomethingNeedDoing.Gui;
 /// <summary>
 /// Macro editor with IDE-like features
 /// </summary>
-public class MacroEditor(IMacroScheduler scheduler, GitMacroManager gitManager, WindowSystem ws)
+public class MacroEditor(IMacroScheduler scheduler, GitMacroManager gitManager, WindowSystem ws, CodeEditor _editor)
 {
     private readonly IMacroScheduler _scheduler = scheduler;
     private readonly GitMacroManager _gitManager = gitManager;
     private UpdateState _updateState = UpdateState.Unknown;
-    private readonly CodeEditor _editor = new();
 
     private enum UpdateState
     {

--- a/SomethingNeedDoing/SomethingNeedDoing.csproj
+++ b/SomethingNeedDoing/SomethingNeedDoing.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ImGuiColorTextEditNetDalamud" Version="0.5.1" />
+		<PackageReference Include="ImGuiColorTextEditNetDalamud" Version="0.6.0" />
 		<PackageReference Include="Laylua" Version="1.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
 		<PackageReference Include="NLua" Version="1.7.5" />

--- a/SomethingNeedDoing/SomethingNeedDoing.csproj
+++ b/SomethingNeedDoing/SomethingNeedDoing.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ImGuiColorTextEditNetDalamud" Version="0.6.0" />
+		<PackageReference Include="ImGuiColorTextEditNetDalamud" Version="0.7.0" />
 		<PackageReference Include="Laylua" Version="1.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
 		<PackageReference Include="NLua" Version="1.7.5" />

--- a/SomethingNeedDoing/SomethingNeedDoing.csproj
+++ b/SomethingNeedDoing/SomethingNeedDoing.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ImGuiColorTextEditNetDalamud" Version="0.7.0" />
+		<PackageReference Include="ImGuiColorTextEditNetDalamud" Version="0.8.0" />
 		<PackageReference Include="Laylua" Version="1.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
 		<PackageReference Include="NLua" Version="1.7.5" />

--- a/SomethingNeedDoing/packages.lock.json
+++ b/SomethingNeedDoing/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "ImGuiColorTextEditNetDalamud": {
         "type": "Direct",
-        "requested": "[0.6.0, )",
-        "resolved": "0.6.0",
-        "contentHash": "2ApNmu/KlNeJ0EPfWuCqDBs6MIybiTltVDxMW24z3vhE4yHoHhEBdwkJlis4kvLYhMGT7P5DI8C7X7D06aGccw=="
+        "requested": "[0.7.0, )",
+        "resolved": "0.7.0",
+        "contentHash": "Id12w/wLo7ySklhmV2r1vG7ID/ZZolHbQs8NVfNo6GSfF8p1PGQaZwvG7sNQDGje6BwZQJhgI/bY2NCk3kWyNQ=="
       },
       "Laylua": {
         "type": "Direct",

--- a/SomethingNeedDoing/packages.lock.json
+++ b/SomethingNeedDoing/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "ImGuiColorTextEditNetDalamud": {
         "type": "Direct",
-        "requested": "[0.5.1, )",
-        "resolved": "0.5.1",
-        "contentHash": "OW1P/z3X2n6nkLgomi0VeVohsxX9ux2kj2Y2yHLVVlFAb0Ds2sSzCiuuebeNb84wR2V8pzpEClF+lQV5eE3kcg=="
+        "requested": "[0.6.0, )",
+        "resolved": "0.6.0",
+        "contentHash": "2ApNmu/KlNeJ0EPfWuCqDBs6MIybiTltVDxMW24z3vhE4yHoHhEBdwkJlis4kvLYhMGT7P5DI8C7X7D06aGccw=="
       },
       "Laylua": {
         "type": "Direct",

--- a/SomethingNeedDoing/packages.lock.json
+++ b/SomethingNeedDoing/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "ImGuiColorTextEditNetDalamud": {
         "type": "Direct",
-        "requested": "[0.7.0, )",
-        "resolved": "0.7.0",
-        "contentHash": "Id12w/wLo7ySklhmV2r1vG7ID/ZZolHbQs8NVfNo6GSfF8p1PGQaZwvG7sNQDGje6BwZQJhgI/bY2NCk3kWyNQ=="
+        "requested": "[0.8.0, )",
+        "resolved": "0.8.0",
+        "contentHash": "qqjiDoNQYLbvp7fNg7vI1mGkedQBI3nDg282/qBmA51HBvL5aIKvLeIpNgBXejIKPpVQWgYf+1UjzW8zBQerfg=="
       },
       "Laylua": {
         "type": "Direct",


### PR DESCRIPTION
Couple things here in SND:
- First I changed the various props to be consistent, same as ReadOnly
- I added a Lua Syntax Highlighter in SND, that adds the SND specific things as identifiers, so they will be highlighted

A lot of changes upstream: https://github.com/OhKannaDuh/DalamudCodeEditor/compare/0.5.1...0.8.0

- Started transitioning a lot of the code base to use Rune rather than char
  - https://learn.microsoft.com/en-us/dotnet/api/system.text.rune
- Added support for multibyte characters in various places
  - This is probably not exhaustive and may need a little work, but worked well in my experience
- Improved handling of Selection
- Ensured Cut/Paste are marked as RequireWritable (This was handled within the functions before)
- Added keybind Ctrl+Backspace to delete word before cursor

This should address https://github.com/Jaksuhn/SomethingNeedDoing/issues/35 & https://github.com/Jaksuhn/SomethingNeedDoing/issues/37