### PR TITLE
LuaRequirePaths - fixes

### DIFF
--- a/SomethingNeedDoing/Gui/Tabs/SettingsTab.cs
+++ b/SomethingNeedDoing/Gui/Tabs/SettingsTab.cs
@@ -1,4 +1,5 @@
-﻿using Dalamud.Interface.Utility.Raii;
+﻿using Dalamud.Interface.Colors;
+using Dalamud.Interface.Utility.Raii;
 using ECommons.ImGuiMethods;
 using SomethingNeedDoing.Gui.Modals;
 
@@ -164,16 +165,31 @@ public static class SettingsTab
             ImGui.TextWrapped("Lua require paths (where to look for Lua modules):");
 
             var paths = C.LuaRequirePaths.ToArray();
-            for (var index = 0; index < paths.Length; index++)
+            using (ImRaii.Table("LuaRequirePaths", 2, ImGuiTableFlags.SizingStretchProp))
             {
-                var path = paths[index];
-
-                if (ImGui.InputText($"Path #{index}", ref path, 200))
+                for (var index = 0; index < paths.Length; index++)
                 {
-                    var newPaths = paths.ToList();
-                    newPaths[index] = path;
-                    C.LuaRequirePaths = [.. newPaths.Where(p => !string.IsNullOrWhiteSpace(p))];
-                    C.Save();
+                    var path = PathHelper.NormalizePath(paths[index]);
+
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+
+                    var isValid = PathHelper.ValidatePath(path);
+                    ImGui.TextColored(isValid ? ImGuiColors.HealerGreen : ImGuiColors.DalamudRed, $"Path #{index}");
+                    if (ImGui.IsItemHovered())
+                    {
+                        ImGui.SetTooltip(isValid ? "This path is valid." : "This path is invalid.");
+                    }
+
+                    ImGui.TableNextColumn();
+
+                    if (ImGui.InputText($"##Path{index}", ref path, 200))
+                    {
+                        var newPaths = paths.ToList();
+                        newPaths[index] = PathHelper.NormalizePath(path);
+                        C.LuaRequirePaths = [.. newPaths.Where(p => !string.IsNullOrWhiteSpace(p))];
+                        C.Save();
+                    }
                 }
             }
 

--- a/SomethingNeedDoing/Utils/LuaExtensions.cs
+++ b/SomethingNeedDoing/Utils/LuaExtensions.cs
@@ -29,7 +29,14 @@ public static class LuaExtensions
     public static void LoadRequirePaths(this Lua lua)
     {
         foreach (var path in C.LuaRequirePaths)
+        {
+            if (!PathHelper.ValidatePath(path))
+            {
+                continue;
+            }
+
             lua.DoString($"table.insert(snd.require.paths, '{path}')");
+        }
     }
 
     public static void ApplyPrintOverride(this Lua lua)

--- a/SomethingNeedDoing/Utils/PathHelper.cs
+++ b/SomethingNeedDoing/Utils/PathHelper.cs
@@ -12,6 +12,7 @@ public static class PathHelper
             return false;
         }
 
+        // Ensure path is absolute and directory exists
         if (!Path.IsPathRooted(path) || !Directory.Exists(path))
         {
             return false;

--- a/SomethingNeedDoing/Utils/PathHelper.cs
+++ b/SomethingNeedDoing/Utils/PathHelper.cs
@@ -1,0 +1,33 @@
+using System.IO;
+
+namespace SomethingNeedDoing.Utils;
+
+public static class PathHelper
+{
+        public static bool ValidatePath(string path)
+    {
+        // Check whitespace and invalid characters
+        if (string.IsNullOrWhiteSpace(path) && !path.Any(c => Path.GetInvalidPathChars().Contains(c)))
+        {
+            return false;
+        }
+
+        if (!Path.IsPathRooted(path) || !Directory.Exists(path))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static string NormalizePath(string input)
+    {
+        if (!ValidatePath(input))
+        {
+            return input;
+        }
+
+        string path = input.Replace('/', '\\');
+        return Path.GetFullPath(path).Replace('\\', '/');
+    }
+}


### PR DESCRIPTION
This PR adds 2 things.

- Paths are formatted to a consistent format on save, removing the ability for users to be users
- Paths are validated before being added to the `snd.require.paths` table
  - This covers point 1 in the case a user deletes/moves a directory that is in required paths
