### PR TITLE
[Wrath] Switch to `RegisterForLease`, fix various methods

### DIFF
--- a/SomethingNeedDoing/External/Wrath.cs
+++ b/SomethingNeedDoing/External/Wrath.cs
@@ -6,15 +6,14 @@ public class Wrath : IPC
 {
     public override string Name => "WrathCombo";
     public override string Repo => Repos.Punish;
-    private static string InternalName => Svc.PluginInterface.InternalName;
 
-    [EzIPC("RegisterForLease")]
-    private readonly Func<string, string, Guid?> _registerForLease = null!;
+    private readonly Func<string, string, Guid?> RegisterForLease = null!;
 
     [LuaFunction(
         description: "Registers for lease",
         parameterDescriptions: ["scriptName"])]
-    public Guid? RegisterForLease(string scriptName) => _registerForLease(InternalName, scriptName);
+    [Changelog(ChangelogAttribute.Unreleased)]
+    public Guid? Register(string scriptName) => RegisterForLease(Svc.PluginInterface.InternalName, scriptName);
 
     [EzIPC]
     [LuaFunction(

--- a/SomethingNeedDoing/External/Wrath.cs
+++ b/SomethingNeedDoing/External/Wrath.cs
@@ -6,12 +6,15 @@ public class Wrath : IPC
 {
     public override string Name => "WrathCombo";
     public override string Repo => Repos.Punish;
+    private static string InternalName => Svc.PluginInterface.InternalName;
 
-    [EzIPC]
+    [EzIPC("RegisterForLease")]
+    private readonly Func<string, string, Guid?> _registerForLease = null!;
+
     [LuaFunction(
-        description: "Registers for lease with callback",
-        parameterDescriptions: ["jobName", "callbackName", "callbackData"])]
-    public readonly Func<string, string, string, Guid?> RegisterForLeaseWithCallback = null!;
+        description: "Registers for lease",
+        parameterDescriptions: ["scriptName"])]
+    public Guid? RegisterForLease(string scriptName) => _registerForLease(InternalName, scriptName);
 
     [EzIPC]
     [LuaFunction(

--- a/SomethingNeedDoing/External/Wrath.cs
+++ b/SomethingNeedDoing/External/Wrath.cs
@@ -46,20 +46,21 @@ public class Wrath : IPC
 
     [EzIPC]
     [LuaFunction(
-        description: "Gets the auto rotation config state")]
-    public readonly Func<AutoRotationConfigOption> GetAutoRotationConfigState = null!;
+        description: $"Gets the auto rotation config state for the given {nameof(AutoRotationConfigOption)}",
+        parameterDescriptions: ["configOption"])]
+    public readonly Func<AutoRotationConfigOption, object?> GetAutoRotationConfigState = null!;
 
     [EzIPC]
     [LuaFunction(
-        description: "Sets the auto rotation config state",
-        parameterDescriptions: ["leaseId", "configOption"])]
-    public readonly Action<Guid, AutoRotationConfigOption> SetAutoRotationConfigState = null!;
+        description: $"Sets the auto rotation config state for the given {nameof(AutoRotationConfigOption)} to the given value (must be of the expected type)",
+        parameterDescriptions: ["leaseId", "configOption", "configValue"])]
+    public readonly Func<Guid, AutoRotationConfigOption, object, SetResult> SetAutoRotationConfigState = null!;
 
     public enum AutoRotationConfigOption
     {
         InCombatOnly = 0, //bool
-        DPSRotationMode = 1,
-        HealerRotationMode = 2,
+        DPSRotationMode = 1, //DPSRotationMode Enum (or int of enum value)
+        HealerRotationMode = 2, //HealerRotationMode Enum (or int of enum value)
         FATEPriority = 3, //bool
         QuestPriority = 4, //bool
         SingleTargetHPP = 5, //int
@@ -71,6 +72,7 @@ public class Wrath : IPC
         AutoCleanse = 11, //bool
         IncludeNPCs = 12, //bool
     }
+
     public enum SetResult
     {
         IGNORED = -1,
@@ -83,5 +85,24 @@ public class Wrath : IPC
         PlayerNotAvailable = 14,
         InvalidConfiguration = 15,
         InvalidValue = 16,
+    }
+
+    public enum DPSRotationMode
+    {
+        Manual = 0,
+        Highest_Max = 1,
+        Lowest_Max = 2,
+        Highest_Current = 3,
+        Lowest_Current = 4,
+        Tank_Target = 5,
+        Nearest = 6,
+        Furthest = 7,
+    }
+
+    public enum HealerRotationMode
+    {
+        Manual = 0,
+        Highest_Current = 1,
+        Lowest_Current = 2,
     }
 }

--- a/SomethingNeedDoing/External/Wrath.cs
+++ b/SomethingNeedDoing/External/Wrath.cs
@@ -25,7 +25,7 @@ public class Wrath : IPC
     [LuaFunction(
         description: "Sets the auto rotation state",
         parameterDescriptions: ["leaseId", "enabled"])]
-    public readonly Action<Guid, bool> SetAutoRotationState = null!;
+    public readonly Func<Guid, bool, SetResult> SetAutoRotationState = null!;
 
     [EzIPC]
     [LuaFunction(
@@ -36,7 +36,7 @@ public class Wrath : IPC
     [LuaFunction(
         description: "Sets the current job auto rotation ready",
         parameterDescriptions: ["leaseId"])]
-    public readonly Action<Guid> SetCurrentJobAutoRotationReady = null!;
+    public readonly Func<Guid, SetResult> SetCurrentJobAutoRotationReady = null!;
 
     [EzIPC]
     [LuaFunction(
@@ -70,5 +70,18 @@ public class Wrath : IPC
         AutoRezDPSJobs = 10, //bool
         AutoCleanse = 11, //bool
         IncludeNPCs = 12, //bool
+    }
+    public enum SetResult
+    {
+        IGNORED = -1,
+        Okay = 0,
+        OkayWorking = 1,
+        IPCDisabled = 10,
+        InvalidLease = 11,
+        BlacklistedLease = 12,
+        Duplicate = 13,
+        PlayerNotAvailable = 14,
+        InvalidConfiguration = 15,
+        InvalidValue = 16,
     }
 }

--- a/SomethingNeedDoing/LuaMacro/Modules/IPCModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/IPCModule.cs
@@ -34,6 +34,9 @@ public class IPCModule : LuaModuleBase
     public override void Register(Lua lua)
     {
         lua.DoString("AutoRotationConfigOption = luanet.import_type('SomethingNeedDoing.External.Wrath.AutoRotationConfigOption')");
+        lua.DoString("AutoRotationConfigOption = luanet.import_type('SomethingNeedDoing.External.Wrath.SetResult')");
+        lua.DoString("AutoRotationConfigOption = luanet.import_type('SomethingNeedDoing.External.Wrath.DPSRotationMode')");
+        lua.DoString("AutoRotationConfigOption = luanet.import_type('SomethingNeedDoing.External.Wrath.HealerRotationMode')");
         lua.DoString($"{ModuleName} = {{}}");
 
         RegisterHelperFunctions(lua);


### PR DESCRIPTION
In this PR:
- [X] Switches to `RegisterForLease` instead of `RegisterForLeaseWithCallback`
- [X] Fixes methods that have incorrect signatures because they now return `SetResult` values
- [X] Fixes the `AutoRotationConfigOption` methods to have correct signatures
  - [X] Increases documentation for these methods
  - [X] Includes the enums for the two `Option`s that did not have their matching type in the code

Maybe another time:
- [ ] Add `RegisterForLeaseWithCallback` ?
  - [ ] Allow IPC method creation in Lua
- [ ] Include other Wrath methods