### PR TITLE
Enum loader

### DIFF
--- a/SomethingNeedDoing/LuaMacro/Modules/ActionsModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/ActionsModule.cs
@@ -11,7 +11,7 @@ public unsafe class ActionsModule : LuaModuleBase
     public override string ModuleName => "Actions";
     public override void Register(NLua.Lua lua)
     {
-        lua.DoString("ActionType = luanet.import_type('FFXIVClientStructs.FFXIV.Client.Game.ActionType')");
+        lua.RegisterEnum<ActionType>();
         base.Register(lua);
     }
 

--- a/SomethingNeedDoing/LuaMacro/Modules/AddonModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/AddonModule.cs
@@ -1,4 +1,5 @@
-﻿using NLua;
+﻿using FFXIVClientStructs.FFXIV.Component.GUI;
+using NLua;
 using SomethingNeedDoing.LuaMacro.Wrappers;
 
 namespace SomethingNeedDoing.LuaMacro.Modules;
@@ -7,7 +8,7 @@ public unsafe class AddonModule : LuaModuleBase
     public override string ModuleName => "Addons";
     public override void Register(Lua lua)
     {
-        lua.DoString("NodeType = luanet.import_type('FFXIVClientStructs.FFXIV.Component.GUI.NodeType')");
+        lua.RegisterEnum<NodeType>();
         base.Register(lua);
     }
 

--- a/SomethingNeedDoing/LuaMacro/Modules/EntityModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/EntityModule.cs
@@ -1,4 +1,6 @@
 ﻿using Dalamud.Game.ClientState.Objects.SubKinds;
+using FFXIVClientStructs.FFXIV.Client.Game.Object;
+using Lumina.Excel.Sheets;
 using NLua;
 using SomethingNeedDoing.LuaMacro.Wrappers;
 
@@ -9,7 +11,7 @@ public unsafe class EntityModule : LuaModuleBase
     protected override object? MetaIndex(LuaTable table, string key) => Svc.Objects[int.Parse(key)] is { } obj ? new EntityWrapper(obj) : null;
     public override void Register(Lua lua)
     {
-        lua.DoString("ObjectKind = luanet.import_type('FFXIVClientStructs.FFXIV.Client.Game.Object.ObjectKind')");
+        lua.RegisterEnum<ObjectKind>();
         base.Register(lua);
     }
 

--- a/SomethingNeedDoing/LuaMacro/Modules/FateModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/FateModule.cs
@@ -8,8 +8,8 @@ public unsafe class FateModule : LuaModuleBase
     public override string ModuleName => "Fates";
     public override void Register(Lua lua)
     {
-        lua.DoString("FateRule = luanet.import_type('SomethingNeedDoing.LuaMacro.Modules.FateModule.FateRule')");
-        lua.DoString("FateState = luanet.import_type('FFXIVClientStructs.FFXIV.Client.Game.Fate.FateState')");
+        lua.RegisterEnum<FateRule>();
+        lua.RegisterEnum<FateState>();
         base.Register(lua);
     }
 

--- a/SomethingNeedDoing/LuaMacro/Modules/IPCModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/IPCModule.cs
@@ -34,7 +34,7 @@ public class IPCModule : LuaModuleBase
 
     public override void Register(Lua lua)
     {
-        lua.RegisterClass<Wrath.AutoRotationConfigOption>();
+        lua.RegisterEnum<Wrath.AutoRotationConfigOption>();
         lua.DoString($"{ModuleName} = {{}}");
 
         RegisterHelperFunctions(lua);

--- a/SomethingNeedDoing/LuaMacro/Modules/IPCModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/IPCModule.cs
@@ -3,6 +3,7 @@ using SomethingNeedDoing.Core.Interfaces;
 using SomethingNeedDoing.Documentation;
 using System.Reflection;
 using System.Linq.Expressions;
+using SomethingNeedDoing.External;
 
 namespace SomethingNeedDoing.LuaMacro.Modules;
 
@@ -33,7 +34,7 @@ public class IPCModule : LuaModuleBase
 
     public override void Register(Lua lua)
     {
-        lua.DoString("AutoRotationConfigOption = luanet.import_type('SomethingNeedDoing.External.Wrath.AutoRotationConfigOption')");
+        lua.RegisterClass<Wrath.AutoRotationConfigOption>();
         lua.DoString($"{ModuleName} = {{}}");
 
         RegisterHelperFunctions(lua);

--- a/SomethingNeedDoing/LuaMacro/Modules/InstancedContentModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/InstancedContentModule.cs
@@ -5,6 +5,7 @@ using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using NLua;
 using SomethingNeedDoing.Core.Interfaces;
 using SomethingNeedDoing.LuaMacro.Wrappers;
+using ContentType = FFXIVClientStructs.FFXIV.Client.Game.Event.ContentType;
 
 namespace SomethingNeedDoing.LuaMacro.Modules;
 /// <summary>
@@ -15,9 +16,9 @@ public unsafe class InstancedContentModule : LuaModuleBase
     public override string ModuleName => "InstancedContent";
     public override void Register(Lua lua)
     {
-        lua.DoString("DynamicEventState = luanet.import_type('FFXIVClientStructs.FFXIV.Client.Game.InstanceContent.DynamicEventState')");
-        lua.DoString("OceanFishingStatus = luanet.import_type('FFXIVClientStructs.FFXIV.Client.Game.InstanceContent.InstanceContentOceanFishing+OceanFishingStatus')");
-        lua.DoString("ContentType = luanet.import_type('FFXIVClientStructs.FFXIV.Client.Game.Event.ContentType')");
+        lua.RegisterEnum<DynamicEventState>();
+        lua.RegisterEnum<InstanceContentOceanFishing.OceanFishingStatus>();
+        lua.RegisterEnum<ContentType>();
         base.Register(lua);
     }
 

--- a/SomethingNeedDoing/LuaMacro/Modules/InstancesModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/InstancesModule.cs
@@ -13,9 +13,9 @@ public unsafe class InstancesModule : LuaModuleBase
     public override string ModuleName => "Instances";
     public override void Register(Lua lua)
     {
-        lua.DoString("OnlineStatus = luanet.import_type('FFXIVClientStructs.FFXIV.Client.UI.Info.OnlineStatus')");
-        lua.DoString("GrandCompany = luanet.import_type('FFXIVClientStructs.FFXIV.Client.UI.Agent.GrandCompany')");
-        lua.DoString("Language = luanet.import_type('FFXIVClientStructs.FFXIV.Client.UI.Info.Language')");
+        lua.RegisterEnum<OnlineStatus>();
+        lua.RegisterEnum<GrandCompany>();
+        lua.RegisterEnum<Language>();
         base.Register(lua);
     }
 

--- a/SomethingNeedDoing/LuaMacro/Modules/InventoryModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/InventoryModule.cs
@@ -13,7 +13,7 @@ public unsafe class InventoryModule : LuaModuleBase
     protected override object? MetaIndex(LuaTable table, string key) => GetInventoryContainer(Enum.Parse<InventoryType>(key));
     public override void Register(Lua lua)
     {
-        lua.DoString("InventoryType = luanet.import_type('FFXIVClientStructs.FFXIV.Client.Game.InventoryType')");
+        lua.RegisterEnum<InventoryType>();
         base.Register(lua);
     }
 

--- a/SomethingNeedDoing/LuaMacro/Modules/PlayerModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/PlayerModule.cs
@@ -12,7 +12,7 @@ public unsafe class PlayerModule : LuaModuleBase
     public override string ModuleName => "Player";
     public override void Register(Lua lua)
     {
-        lua.DoString("WeeklyBingoTaskStatus = luanet.import_type('FFXIVClientStructs.FFXIV.Client.Game.UI.PlayerState+WeeklyBingoTaskStatus')");
+        lua.RegisterEnum<WeeklyBingoTaskStatus>();
         base.Register(lua);
     }
 

--- a/SomethingNeedDoing/LuaMacro/NLuaMacroEngine.cs
+++ b/SomethingNeedDoing/LuaMacro/NLuaMacroEngine.cs
@@ -101,7 +101,6 @@ public class NLuaMacroEngine(LuaModuleManager moduleManager, CleanupManager clea
             lua.RegisterInternalFunctions();
             lua.SetTriggerEventData(triggerArgs);
             lua.RegisterClass<Svc>();
-            lua.DoString("luanet.load_assembly('FFXIVClientStructs')");
             moduleManager.RegisterAll(lua);
 
             var engines = new List<IEngine>

--- a/SomethingNeedDoing/Utils/LuaExtensions.cs
+++ b/SomethingNeedDoing/Utils/LuaExtensions.cs
@@ -20,7 +20,11 @@ public static class LuaExtensions
     /// </summary>
     public static void RegisterClass<T>(this Lua lua)
     {
-        lua.LoadAssembly(typeof(T).Assembly.GetName().Name ?? "");
+        var assembly = typeof(T).Assembly.GetName().Name;
+        if (assembly is null)
+            throw new ArgumentException($"Assembly name for type {typeof(T).FullName} is null.");
+
+        lua.LoadAssembly(assembly);
         lua.DoString(@$"{typeof(T).Name} = luanet.import_type('{typeof(T).FullName}')()");
     }
 
@@ -28,18 +32,12 @@ public static class LuaExtensions
     /// Registers an enum as a dynamically accessible object. Must be called after <see cref="Lua.LoadCLRPackage"/>
     /// This funcion just forwards to RegisterClass and exists only for clarity.
     /// </summary>
-    public static void RegisterEnum<T>(this Lua lua) where T : Enum
-    {
-        lua.RegisterClass<T>();
-    }
+    public static void RegisterEnum<T>(this Lua lua) where T : Enum => lua.RegisterClass<T>();
 
     // <summary>
     /// Loads a .NET assembly into the Lua state.
     /// </summary>
-    public static void LoadAssembly(this Lua lua, string assembly)
-    {
-        lua.DoString($"luanet.load_assembly('{assembly}')");
-    }
+    public static void LoadAssembly(this Lua lua, string assembly) => lua.DoString($"luanet.load_assembly('{assembly}')");
 
     public static void LoadPackageSearcherSnippet(this Lua lua) => lua.DoString(LuaCodeSnippets.PackageSearchersSnippet);
 

--- a/SomethingNeedDoing/Utils/LuaExtensions.cs
+++ b/SomethingNeedDoing/Utils/LuaExtensions.cs
@@ -20,8 +20,25 @@ public static class LuaExtensions
     /// </summary>
     public static void RegisterClass<T>(this Lua lua)
     {
-        lua.DoString(@$"luanet.load_assembly('{typeof(T).Assembly.GetName().Name}')");
+        lua.LoadAssembly(typeof(T).Assembly.GetName().Name ?? "");
         lua.DoString(@$"{typeof(T).Name} = luanet.import_type('{typeof(T).FullName}')()");
+    }
+
+    /// <summary>
+    /// Registers an enum as a dynamically accessible object. Must be called after <see cref="Lua.LoadCLRPackage"/>
+    /// This funcion just forwards to RegisterClass and exists only for clarity.
+    /// </summary>
+    public static void RegisterEnum<T>(this Lua lua) where T : Enum
+    {
+        lua.RegisterClass<T>();
+    }
+
+    // <summary>
+    /// Loads a .NET assembly into the Lua state.
+    /// </summary>
+    public static void LoadAssembly(this Lua lua, string assembly)
+    {
+        lua.DoString($"luanet.load_assembly('{assembly}')");
     }
 
     public static void LoadPackageSearcherSnippet(this Lua lua) => lua.DoString(LuaCodeSnippets.PackageSearchersSnippet);


### PR DESCRIPTION
Create a function to register enums into the lua state. This method just propogates to `RegisterClass` but I figured also having `RegisterEnum` was more readable.

I also added `LoadAssembly`, which I also pretty much made useless by `RegisterEnum`, since it now ensures the assembly for the enum is loaded.

 `lua.DoString("luanet.load_assembly('FFXIVClientStructs')");` was removed as it is loaded implicitly when its enums are loaded now.
 
 This came about when Nonu was asking for help with an IPC. I realised that the `SomethingNeedDoing` assmebly wasn't available to the lua state, and so the enums within it weren't even if you loaded them. So I decided to make that all implicit and remove the confusion.
 
 `luanet.load_assembly` likely shouldn't be needed anywhere, as `RegisterEnum` and `RegisterClass` should be used. This should only be used if the user is trying to load a custom type from something, though I don't know if that works for dlls outside of SND.