### PR TITLE
Fix Wrath IPC, add other Wrath IPC methods

### DIFF
--- a/SomethingNeedDoing/External/Wrath.cs
+++ b/SomethingNeedDoing/External/Wrath.cs
@@ -8,6 +8,11 @@ public class Wrath : IPC
     public override string Repo => Repos.Punish;
 
     [EzIPC]
+    [LuaFunction(
+        description: "Checks that Wrath's IPC is completely ready for use")]
+    public readonly Func<bool> IPCReady = null!;
+
+    [EzIPC]
     private readonly Func<string, string, Guid?> RegisterForLease = null!;
 
     [LuaFunction(

--- a/SomethingNeedDoing/External/Wrath.cs
+++ b/SomethingNeedDoing/External/Wrath.cs
@@ -61,7 +61,7 @@ public class Wrath : IPC
         description: "Lists all internal names of options (in a dictionary, keyed to the parent combo's internal name) for the given job ID",
         parameterDescriptions: ["jobId"])]
     [Changelog(ChangelogAttribute.Unreleased)]
-    public readonly Func<uint, Dictionary<string, List<string>?>> GetComboOptionNamesForJob = null!;
+    public readonly Func<uint, Dictionary<string, List<string>>?> GetComboOptionNamesForJob = null!;
 
     [EzIPC]
     [LuaFunction(

--- a/SomethingNeedDoing/External/Wrath.cs
+++ b/SomethingNeedDoing/External/Wrath.cs
@@ -23,23 +23,23 @@ public class Wrath : IPC
 
     [EzIPC]
     [LuaFunction(
-        description: "Gets the auto rotation state")]
+        description: "Gets the Auto Rotation state")]
     public readonly Func<bool> GetAutoRotationState = null!;
 
     [EzIPC]
     [LuaFunction(
-        description: "Sets the auto rotation state",
+        description: "Sets the Auto Rotation state",
         parameterDescriptions: ["leaseId", "enabled"])]
     public readonly Func<Guid, bool, SetResult> SetAutoRotationState = null!;
 
     [EzIPC]
     [LuaFunction(
-        description: "Checks if the current job auto rotation is ready")]
+        description: "Checks if the current job is Auto Rotation ready (as in, `SetAutoRotationState` would set no new Combos/Options, it would only Lock them)")]
     public readonly Func<bool> IsCurrentJobAutoRotationReady = null!;
 
     [EzIPC]
     [LuaFunction(
-        description: "Sets the current job auto rotation ready",
+        description: "Sets the current job to be Auto Rotation ready",
         parameterDescriptions: ["leaseId"])]
     public readonly Func<Guid, SetResult> SetCurrentJobAutoRotationReady = null!;
 

--- a/SomethingNeedDoing/External/Wrath.cs
+++ b/SomethingNeedDoing/External/Wrath.cs
@@ -1,6 +1,4 @@
 ﻿using ECommons.EzIpcManager;
-using ECommons.Loader;
-using ECommons.Logging;
 using SomethingNeedDoing.Core.Interfaces;
 
 namespace SomethingNeedDoing.External;
@@ -45,6 +43,48 @@ public class Wrath : IPC
         description: "Releases control",
         parameterDescriptions: ["leaseId"])]
     public readonly Action<Guid> ReleaseControl = null!;
+
+    [EzIPC]
+    [LuaFunction(
+        description: "Lists all internal names of combos for the given job ID",
+        parameterDescriptions: ["jobId"])]
+    [Changelog(ChangelogAttribute.Unreleased)]
+    public readonly Func<uint, List<string>?> GetComboNamesForJob = null!;
+
+    [EzIPC]
+    [LuaFunction(
+        description: "Lists all internal names of options (in a dictionary, keyed to the parent combo's internal name) for the given job ID",
+        parameterDescriptions: ["jobId"])]
+    [Changelog(ChangelogAttribute.Unreleased)]
+    public readonly Func<uint, Dictionary<string, List<string>?>> GetComboOptionNamesForJob = null!;
+
+    [EzIPC]
+    [LuaFunction(
+        description: "Sets the state of a Combo, given its internal name (or ID, as a string) (both the newComboState and the newComboAutoModeState should be true to enable them)",
+        parameterDescriptions: ["leaseId", "comboInternalName", "newComboState", "newComboAutoModeState"])]
+    [Changelog(ChangelogAttribute.Unreleased)]
+    public readonly Func<Guid, string, bool, bool, SetResult> SetComboState = null!;
+
+    [EzIPC]
+    [LuaFunction(
+        description: "Gets the state of a Combo, given its internal name (or ID, as a string) (return key 0 is the Combo's state, key 1 is the Combo's Auto-Mode State)",
+        parameterDescriptions: ["leaseId", "comboInternalName"])]
+    [Changelog(ChangelogAttribute.Unreleased)]
+    public readonly Func<Guid, string, Dictionary<int, bool>?> GetComboState = null!;
+
+    [EzIPC]
+    [LuaFunction(
+        description: "Sets the state of a Combo's Option, given its internal name (or ID, as a string)",
+        parameterDescriptions: ["leaseId", "optionInternalName", "newOptionState"])]
+    [Changelog(ChangelogAttribute.Unreleased)]
+    public readonly Func<Guid, string, bool, SetResult> SetComboOptionState = null!;
+
+    [EzIPC]
+    [LuaFunction(
+        description: "Gets the state of a Combo's Option, given its internal name (or ID, as a string)",
+        parameterDescriptions: ["leaseId", "optionInternalName"])]
+    [Changelog(ChangelogAttribute.Unreleased)]
+    public readonly Func<Guid, string, bool> GetComboOptionState = null!;
 
     [EzIPC]
     [LuaFunction(

--- a/SomethingNeedDoing/External/Wrath.cs
+++ b/SomethingNeedDoing/External/Wrath.cs
@@ -1,4 +1,6 @@
 ﻿using ECommons.EzIpcManager;
+using ECommons.Loader;
+using ECommons.Logging;
 using SomethingNeedDoing.Core.Interfaces;
 
 namespace SomethingNeedDoing.External;
@@ -7,6 +9,7 @@ public class Wrath : IPC
     public override string Name => "WrathCombo";
     public override string Repo => Repos.Punish;
 
+    [EzIPC]
     private readonly Func<string, string, Guid?> RegisterForLease = null!;
 
     [LuaFunction(

--- a/SomethingNeedDoing/External/Wrath.cs
+++ b/SomethingNeedDoing/External/Wrath.cs
@@ -72,10 +72,10 @@ public class Wrath : IPC
 
     [EzIPC]
     [LuaFunction(
-        description: "Gets the state of a Combo, given its internal name (or ID, as a string) (return key 0 is the Combo's state, key 1 is the Combo's Auto-Mode State)",
+        description: "Gets the state of a Combo, given its internal name (or ID, as a string)\n(this returns a table accessible via ComboStateKeys as keys)",
         parameterDescriptions: ["comboInternalName"])]
     [Changelog(ChangelogAttribute.Unreleased)]
-    public readonly Func<string, Dictionary<int, bool>?> GetComboState = null!;
+    public readonly Func<string, Dictionary<ComboStateKeys, bool>?> GetComboState = null!;
 
     [EzIPC]
     [LuaFunction(
@@ -151,5 +151,11 @@ public class Wrath : IPC
         Manual = 0,
         Highest_Current = 1,
         Lowest_Current = 2,
+    }
+
+    public enum ComboStateKeys
+    {
+        Enabled,
+        AutoMode,
     }
 }

--- a/SomethingNeedDoing/External/Wrath.cs
+++ b/SomethingNeedDoing/External/Wrath.cs
@@ -73,9 +73,9 @@ public class Wrath : IPC
     [EzIPC]
     [LuaFunction(
         description: "Gets the state of a Combo, given its internal name (or ID, as a string) (return key 0 is the Combo's state, key 1 is the Combo's Auto-Mode State)",
-        parameterDescriptions: ["leaseId", "comboInternalName"])]
+        parameterDescriptions: ["comboInternalName"])]
     [Changelog(ChangelogAttribute.Unreleased)]
-    public readonly Func<Guid, string, Dictionary<int, bool>?> GetComboState = null!;
+    public readonly Func<string, Dictionary<int, bool>?> GetComboState = null!;
 
     [EzIPC]
     [LuaFunction(
@@ -87,9 +87,9 @@ public class Wrath : IPC
     [EzIPC]
     [LuaFunction(
         description: "Gets the state of a Combo's Option, given its internal name (or ID, as a string)",
-        parameterDescriptions: ["leaseId", "optionInternalName"])]
+        parameterDescriptions: ["optionInternalName"])]
     [Changelog(ChangelogAttribute.Unreleased)]
-    public readonly Func<Guid, string, bool> GetComboOptionState = null!;
+    public readonly Func<string, bool> GetComboOptionState = null!;
 
     [EzIPC]
     [LuaFunction(

--- a/SomethingNeedDoing/LuaMacro/Modules/IPCModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/IPCModule.cs
@@ -38,6 +38,7 @@ public class IPCModule : LuaModuleBase
         lua.RegisterEnum<Wrath.SetResult>();
         lua.RegisterEnum<Wrath.DPSRotationMode>();
         lua.RegisterEnum<Wrath.HealerRotationMode>();
+        lua.RegisterEnum<Wrath.ComboStateKeys>();
         lua.DoString($"{ModuleName} = {{}}");
 
         RegisterHelperFunctions(lua);

--- a/SomethingNeedDoing/LuaMacro/Modules/IPCModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/IPCModule.cs
@@ -1,3 +1,4 @@
+using ECommons.Logging;
 using NLua;
 using SomethingNeedDoing.Core.Interfaces;
 using SomethingNeedDoing.Documentation;
@@ -183,6 +184,19 @@ public class IPCModule : LuaModuleBase
                         parameters.Add((paramDesc1 ?? "param1", LuaTypeConverter.GetLuaType(genericArgs[1]), paramDesc1));
                         parameters.Add((paramDesc2 ?? "param2", LuaTypeConverter.GetLuaType(genericArgs[2]), paramDesc2));
                         returnType = LuaTypeConverter.GetLuaType(genericArgs[3]);
+                    }
+                    else if (genericType == typeof(Func<,,,,>))
+                    {
+                        // Func<T1, T2, T3, T4, TResult> - four parameters, one return type
+                        var paramDesc0 = attr.ParameterDescriptions?.ElementAtOrDefault(0);
+                        var paramDesc1 = attr.ParameterDescriptions?.ElementAtOrDefault(1);
+                        var paramDesc2 = attr.ParameterDescriptions?.ElementAtOrDefault(2);
+                        var paramDesc3 = attr.ParameterDescriptions?.ElementAtOrDefault(3);
+                        parameters.Add((paramDesc0 ?? "param0", LuaTypeConverter.GetLuaType(genericArgs[0]), paramDesc0));
+                        parameters.Add((paramDesc1 ?? "param1", LuaTypeConverter.GetLuaType(genericArgs[1]), paramDesc1));
+                        parameters.Add((paramDesc2 ?? "param2", LuaTypeConverter.GetLuaType(genericArgs[2]), paramDesc2));
+                        parameters.Add((paramDesc3 ?? "param3", LuaTypeConverter.GetLuaType(genericArgs[3]), paramDesc3));
+                        returnType = LuaTypeConverter.GetLuaType(genericArgs[4]);
                     }
                     else if (genericType == typeof(Action<,,>))
                     {

--- a/SomethingNeedDoing/LuaMacro/Modules/IPCModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/IPCModule.cs
@@ -1,4 +1,3 @@
-using ECommons.Logging;
 using NLua;
 using SomethingNeedDoing.Core.Interfaces;
 using SomethingNeedDoing.Documentation;


### PR DESCRIPTION
- [X] Restores the mistakenly removed `EzIPC` Attribute back to `RegisterForLease`,\
      fixing the IPC not being usable
- [X] Adds other Wrath methods
  - [X] `IPCReady`
  - [X] `GetComboNamesForJob`
  - [X] `GetComboOptionNamesForJob`
  - [X] `SetComboState`
  - [X] `GetComboState`
  - [X] `SetComboOptionState`
  - [X] `GetComboOptionState`
- [X] Adds support to `IPCModule` for 4param+return IPC methods

The only missing Wrath IPC methods now are:
- `IsCurrentJobConfiguredOn`
- `IsCurrentJobAutoModeOn`

Both of which would really want the associated Enums added, making them heavy, in addition to already not really being recommended usage of the IPC.