### PR TITLE
[Wrath] Update Auto Rotation Config Enum

### DIFF
--- a/SomethingNeedDoing/External/Wrath.cs
+++ b/SomethingNeedDoing/External/Wrath.cs
@@ -118,6 +118,10 @@ public class Wrath : IPC
         AutoRezDPSJobs = 10, //bool
         AutoCleanse = 11, //bool
         IncludeNPCs = 12, //bool
+        OnlyAttackInCombat = 13, // bool
+        OrbwalkerIntegration = 14, // bool
+        AutoRezOutOfParty = 15, // bool
+        DPSAoETargets = 16, // int? (can be set to null to disable aoe'ing)
     }
 
     public enum SetResult

--- a/SomethingNeedDoing/External/Wrath.cs
+++ b/SomethingNeedDoing/External/Wrath.cs
@@ -121,7 +121,7 @@ public class Wrath : IPC
         OnlyAttackInCombat = 13, // bool
         OrbwalkerIntegration = 14, // bool
         AutoRezOutOfParty = 15, // bool
-        DPSAoETargets = 16, // int? (can be set to null to disable aoe'ing)
+        DPSAoETargets = 16, // int
         SingleTargetExcogHPP = 17, // int
     }
 

--- a/SomethingNeedDoing/External/Wrath.cs
+++ b/SomethingNeedDoing/External/Wrath.cs
@@ -122,6 +122,7 @@ public class Wrath : IPC
         OrbwalkerIntegration = 14, // bool
         AutoRezOutOfParty = 15, // bool
         DPSAoETargets = 16, // int? (can be set to null to disable aoe'ing)
+        SingleTargetExcogHPP = 17, // int
     }
 
     public enum SetResult


### PR DESCRIPTION
This updates the `AutoRotationConfigOption` to match the latest options in Wrath Combo.

> [!IMPORTANT]
> Entry 16 depends on PunishXIV/WrathCombo#728 to actually work in practice.
> Entry 17 depends on PunishXIV/WrathCombo#720 to actually work in practice.
> Despite that, it will only give a warning if a SND script uses a not-yet-merged Option like 16, so it is safe to merge anyway; both PRs are expected to be in Wrath's 7.3 update anyway.