### PR TITLE
Add Excel Count, GetProperty and fix Addon NodeWrapper.Text

### DIFF
--- a/SomethingNeedDoing/LuaMacro/Modules/ExcelModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/ExcelModule.cs
@@ -133,6 +133,8 @@ public class ExcelModule : LuaModuleBase
 
         [LuaDocs] public object? this[string propertyName] => GetPropertyValue(row, propertyName);
 
+        [LuaDocs] public object? GetProperty(string propertyName) => GetPropertyValue(row, propertyName);
+
         private static object? GetPropertyValue(object? obj, string propertyName)
         {
             var property = obj?.GetType().GetProperty(propertyName, PropertyFlags);

--- a/SomethingNeedDoing/LuaMacro/Modules/ExcelModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/ExcelModule.cs
@@ -111,6 +111,7 @@ public class ExcelModule : LuaModuleBase
         }
 
         [LuaDocs]
+        [Changelog(ChangelogAttribute.Unreleased)]
         public int Count
         {
             get
@@ -133,7 +134,9 @@ public class ExcelModule : LuaModuleBase
 
         [LuaDocs] public object? this[string propertyName] => GetPropertyValue(row, propertyName);
 
-        [LuaDocs] public object? GetProperty(string propertyName) => GetPropertyValue(row, propertyName);
+        [LuaDocs]
+        [Changelog(ChangelogAttribute.Unreleased)]
+        public object? GetProperty(string propertyName) => GetPropertyValue(row, propertyName);
 
         private static object? GetPropertyValue(object? obj, string propertyName)
         {

--- a/SomethingNeedDoing/LuaMacro/Modules/ExcelModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/ExcelModule.cs
@@ -110,6 +110,16 @@ public class ExcelModule : LuaModuleBase
             return row == null ? null : new ExcelRowWrapper(row, rowId, subRowId);
         }
 
+        [LuaDocs]
+        public int Count
+        {
+            get
+            {
+                var prop = sheet.GetType().GetProperty(nameof(ExcelSheet<>.Count));
+                return prop?.GetValue(sheet) is int count ? count : 0;
+            }
+        }
+
         public override string ToString()
         {
             return $"{(isSubrowSheet ? nameof(SubrowExcelSheet<>) : nameof(ExcelSheet<>))}<{GetGenericSheetType(sheet.GetType())?.Name}>";

--- a/SomethingNeedDoing/LuaMacro/Wrappers/AddonWrapper.cs
+++ b/SomethingNeedDoing/LuaMacro/Wrappers/AddonWrapper.cs
@@ -53,7 +53,7 @@ public unsafe class NodeWrapper : IWrapper
 
     [LuaDocs] public uint Id => Node->NodeId;
     [LuaDocs] public bool IsVisible => Node->IsVisible();
-    [LuaDocs] public string Text { get => Node->GetAsAtkTextNode()->NodeText.ToString(); set => Node->GetAsAtkTextNode()->NodeText.SetString(value); }
+    [LuaDocs] public string Text { get => Node->GetAsAtkTextNode()->NodeText.GetText(); set => Node->GetAsAtkTextNode()->NodeText.SetString(value); }
     [LuaDocs] public NodeType NodeType => Node->Type;
 }
 


### PR DESCRIPTION
I have been migrating my legacy snd scripts to use the new lua, and have run into some issues - raising this PR with fixes for them.

- Excel sheet `Count`
  - not an issue, but the data is there on the underlying sheet and is useful so figured might as well add it while i'm here
- Excel row explicit `GetProperty`
  - the existing implicit `this[string propertyName]` property getter has extreme performance issues. Not sure why, and I don't really have the expertise to go debugging further into the C#/lua interop. For reproduction, the following script in prod takes 15s+ to complete and the entire game locks up for that whole duration (windows will even prompt to terminate the unresponsive game after a bit):
    ```
    local sheet = Excel.Item
    local startTime = os.clock()
    for i = 0, 49000 do
      local name = sheet:GetRow(i).Name
    end
    local endTime = os.clock()
    yield("/e "..(endTime - startTime))
    ```
   - the same thing happens for `sheet:GetRow(i)["Name"]`
   - Listing the function with an explicit name and calling `sheet:GetRow(i):GetProperty("Name")` appears to resolve the issue (completes in <0.1s).
     - Also has the nice added benefit of appearing in the Lua explorer (the `[]` getter does not):
       <img width="589" height="225" alt="ffxiv_dx11_2025-08-11_15-00-04" src="https://github.com/user-attachments/assets/da8cef70-1789-4d3d-a56d-f58d7070eccf" />
- changed Addon NodeWrapper to use `GetText()` instead of `ToString()`
  - have run into some node strings which do not get properly extracted with `ToString`
  - for reproduction: Open Timers -> Next Mission Allowance to get the GC Mission Window:
    <img width="838" height="607" alt="ffxiv_dx11_2025-08-11_15-08-25" src="https://github.com/user-attachments/assets/8eaf40b6-5b1b-4eb4-9c26-a169d34de3c2" />
    Then run the script:
    ```
    for job_id = 8, 15 do
      local item = Addons.GetAddon("ContentsInfoDetail"):GetNode(1, 2, job_id - 2, 4).Text
      local count = Addons.GetAddon("ContentsInfoDetail"):GetNode(1, 2, job_id - 2, 7).Text
      yield("/e item: "..item)
      yield("/e count: "..count)
    end
    ```
    The echo will be:
    <img width="107" height="132" alt="ffxiv_dx11_2025-08-11_15-12-23" src="https://github.com/user-attachments/assets/9057e267-65a7-40ac-9067-47cfff39c812" />
    As the `item` string contains some kind of garbage data. The strings are not actually `nil`, but they appear to contain unusable junk (or at least, something other than just the straight text).
    Using `GetText` this instead outputs:
    <img width="317" height="261" alt="ffxiv_dx11_2025-08-11_15-14-00" src="https://github.com/user-attachments/assets/7c8ba9a6-61ce-4588-836b-bfc49e663351" />
  - In the legacy SND this was also `GetText()` for `NodeType.Text`, so I'm fairly sure this is safe: https://github.com/Jaksuhn/SomethingNeedDoingLegacy/blob/e76eb8b30439ab07a0a366cb0090289e0d0f334e/SomethingNeedDoing/Macros/LuaFunctions/Addons.cs#L229

