### PR TITLE
Add more AutoRetainer IPC

### DIFF
--- a/SomethingNeedDoing/External/AutoRetainer.cs
+++ b/SomethingNeedDoing/External/AutoRetainer.cs
@@ -118,12 +118,21 @@ public class AutoRetainer : IPC
     [Changelog("12.19")]
     public OfflineCharacterDataWrapper GetOfflineCharacterData(ulong cid) => new(StaticsService.AutoRetainerApi.GetOfflineCharacterData(cid));
 
+    [LuaFunction(
+        description: "Sets suppressed state in which AutoRetainer will not perform any actions regardless of configuration",
+        parameterDescriptions: ["boolean"])]
+    public void SetSuppressed(bool suppressed) => StaticsService.AutoRetainerApi.Suppressed = suppressed;
+
+    [LuaFunction(description: "Marks character post-processing as complete")]
+    public void FinishCharacterPostProcess() => StaticsService.AutoRetainerApi.FinishCharacterPostProcess();
+
     public class OfflineCharacterDataWrapper(OfflineCharacterData data) : IWrapper
     {
         [LuaDocs][Changelog("12.19")] public ulong CID => data.CID;
         [LuaDocs][Changelog("12.19")] public string Name => data.Name;
         [LuaDocs][Changelog("12.19")] public string World => data.World;
         [LuaDocs][Changelog("12.19")] public bool Enabled => data.Enabled;
+        [LuaDocs] public bool WorkshopEnabled => data.WorkshopEnabled;
         [LuaDocs][Changelog("12.19")] public List<OfflineRetainerDataWrapper> RetainerData => [.. data.RetainerData.Select(x => new OfflineRetainerDataWrapper(x))];
         [LuaDocs][Changelog("12.19")] public uint InventorySpace => data.InventorySpace;
         [LuaDocs][Changelog("12.19")] public uint VentureCoffers => data.VentureCoffers;
@@ -135,6 +144,7 @@ public class AutoRetainer : IPC
         [LuaDocs][Changelog("12.19")] public bool RetainersAwaitingProcessing => RetainerData.Any(x => x.HasVenture && x.VentureEndsAt <= TimeProvider.System.GetUtcNow().ToUnixTimeSeconds());
         [LuaDocs][Changelog("12.19")] public bool SubsAwaitingProcessing => OfflineSubmarineData.Any(x => x.ReturnTime <= TimeProvider.System.GetUtcNow().ToUnixTimeSeconds());
         [LuaDocs][Changelog("12.19")] public bool AnyAwaitingProcessing => RetainersAwaitingProcessing || SubsAwaitingProcessing;
+        [LuaDocs] public List<short> ClassJobLevelArray => [.. data.ClassJobLevelArray];
     }
 
     public class OfflineRetainerDataWrapper(OfflineRetainerData data) : IWrapper

--- a/SomethingNeedDoing/External/AutoRetainer.cs
+++ b/SomethingNeedDoing/External/AutoRetainer.cs
@@ -124,10 +124,6 @@ public class AutoRetainer : IPC
     [Changelog(ChangelogAttribute.Unreleased)]
     public void SetSuppressed(bool suppressed) => StaticsService.AutoRetainerApi.Suppressed = suppressed;
 
-    [LuaFunction(description: "Marks character post-processing as complete")]
-    [Changelog(ChangelogAttribute.Unreleased)]
-    public void FinishCharacterPostProcess() => StaticsService.AutoRetainerApi.FinishCharacterPostProcess();
-
     public class OfflineCharacterDataWrapper(OfflineCharacterData data) : IWrapper
     {
         [LuaDocs][Changelog("12.19")] public ulong CID => data.CID;

--- a/SomethingNeedDoing/External/AutoRetainer.cs
+++ b/SomethingNeedDoing/External/AutoRetainer.cs
@@ -121,9 +121,11 @@ public class AutoRetainer : IPC
     [LuaFunction(
         description: "Sets suppressed state in which AutoRetainer will not perform any actions regardless of configuration",
         parameterDescriptions: ["boolean"])]
+    [Changelog(ChangelogAttribute.Unreleased)]
     public void SetSuppressed(bool suppressed) => StaticsService.AutoRetainerApi.Suppressed = suppressed;
 
     [LuaFunction(description: "Marks character post-processing as complete")]
+    [Changelog(ChangelogAttribute.Unreleased)]
     public void FinishCharacterPostProcess() => StaticsService.AutoRetainerApi.FinishCharacterPostProcess();
 
     public class OfflineCharacterDataWrapper(OfflineCharacterData data) : IWrapper
@@ -132,7 +134,7 @@ public class AutoRetainer : IPC
         [LuaDocs][Changelog("12.19")] public string Name => data.Name;
         [LuaDocs][Changelog("12.19")] public string World => data.World;
         [LuaDocs][Changelog("12.19")] public bool Enabled => data.Enabled;
-        [LuaDocs] public bool WorkshopEnabled => data.WorkshopEnabled;
+        [LuaDocs][Changelog(ChangelogAttribute.Unreleased)] public bool WorkshopEnabled => data.WorkshopEnabled;
         [LuaDocs][Changelog("12.19")] public List<OfflineRetainerDataWrapper> RetainerData => [.. data.RetainerData.Select(x => new OfflineRetainerDataWrapper(x))];
         [LuaDocs][Changelog("12.19")] public uint InventorySpace => data.InventorySpace;
         [LuaDocs][Changelog("12.19")] public uint VentureCoffers => data.VentureCoffers;
@@ -144,7 +146,7 @@ public class AutoRetainer : IPC
         [LuaDocs][Changelog("12.19")] public bool RetainersAwaitingProcessing => RetainerData.Any(x => x.HasVenture && x.VentureEndsAt <= TimeProvider.System.GetUtcNow().ToUnixTimeSeconds());
         [LuaDocs][Changelog("12.19")] public bool SubsAwaitingProcessing => OfflineSubmarineData.Any(x => x.ReturnTime <= TimeProvider.System.GetUtcNow().ToUnixTimeSeconds());
         [LuaDocs][Changelog("12.19")] public bool AnyAwaitingProcessing => RetainersAwaitingProcessing || SubsAwaitingProcessing;
-        [LuaDocs] public List<short> ClassJobLevelArray => [.. data.ClassJobLevelArray];
+        [LuaDocs][Changelog(ChangelogAttribute.Unreleased)] public List<short> ClassJobLevelArray => [.. data.ClassJobLevelArray];
     }
 
     public class OfflineRetainerDataWrapper(OfflineRetainerData data) : IWrapper


### PR DESCRIPTION
- SetSuppressed
- ~~FinishCharacterPostProcess~~
- OfflineCharacterData.WorkshopEnabled
- OfflineCharacterData.ClassJobLevelArray

These are all functions/members that were previously accessible on the legacy SND. I have various scripts that were dependent on these, have tested and they now appear to be working with these changes.

Wasn't sure if you'd want something for the Changelog, so just left it out for now.