### PR TITLE
Set MacroType.Lua in LuaEngine.ExecuteAsync

### DIFF
--- a/SomethingNeedDoing/LuaMacro/Modules/Engines/LuaEngine.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/Engines/LuaEngine.cs
@@ -29,7 +29,7 @@ public class LuaEngine : IEngine
     {
         try
         {
-            var tempMacro = new TemporaryMacro(content);
+            var tempMacro = new TemporaryMacro(content) { Type = MacroType.Lua };
             await _luaEngine.StartMacro(tempMacro, cancellationToken);
         }
         catch (Exception ex)


### PR DESCRIPTION
This change I'm less sure about because I don't really have anything I regularly use that makes use of it - but when testing I could not get `Engines.NLua.RunAsync(content)` to work as expected. The following test case:
```
yield("/e test")
Engines.Run("/e test run native")
Engines.Run("yield(\"/e test run lua\")")
Engines.RunAsync("/e test run native async")
Engines.RunAsync("yield(\"/e test run lua async\")")
Engines.Native.Run("/e test run native explicit")
Engines.NLua.Run("yield(\"/e test run lua explicit\")")
Engines.Native.RunAsync("/e test run native async explicit")
Engines.NLua.RunAsync("yield(\"/e test run lua async explicit\")")
```
fails on all 4 of the lua calls with:
<img width="2063" height="463" alt="ffxiv_dx11_2025-08-11_23-19-49" src="https://github.com/user-attachments/assets/9ecf5f54-4b38-4722-a615-e7b118f011ad" />
and only the 4 native calls succeed:
<img width="243" height="109" alt="ffxiv_dx11_2025-08-11_23-21-32" src="https://github.com/user-attachments/assets/3148e84d-4d10-4788-b218-2c395db3a5ce" />

From what I can tell, this is because `TemporaryMacro` is created as a `MacroType.Native`, then passed into the lua engine to run. [But the engine immediately checks the MacroType and throws because it's not Lua](https://github.com/Jaksuhn/SomethingNeedDoing/blob/b54622fd2cb2243651f6b224118d17bd8e70deb9/SomethingNeedDoing/LuaMacro/NLuaMacroEngine.cs#L65).

with the fix below, all 8 calls run as expected:
<img width="250" height="157" alt="ffxiv_dx11_2025-08-11_23-22-15" src="https://github.com/user-attachments/assets/548c60da-abaf-4d0a-88af-28d91d800691" />

