### PR TITLE
#69 move MacroExecutionRequested hookup to NLuaMacroEngine

### DIFF
--- a/SomethingNeedDoing/LuaMacro/Modules/Engines/LuaEngine.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/Engines/LuaEngine.cs
@@ -14,13 +14,6 @@ public class LuaEngine : IEngine
     /// <inheritdoc/>
     public event EventHandler<MacroExecutionRequestedEventArgs>? MacroExecutionRequested;
 
-    public LuaEngine(NLuaMacroEngine luaEngine)
-    {
-        // Forward macro execution requests from the Lua engine
-        luaEngine.MacroExecutionRequested += (sender, e) =>
-            MacroExecutionRequested?.Invoke(this, e);
-    }
-
     public async Task ExecuteAsync(string content, CancellationToken cancellationToken = default)
     {
         try

--- a/SomethingNeedDoing/LuaMacro/Modules/Engines/NativeEngine.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/Engines/NativeEngine.cs
@@ -9,7 +9,7 @@ namespace SomethingNeedDoing.LuaMacro.Modules.Engines;
 /// <summary>
 /// Engine for executing native commands.
 /// </summary>
-public class NativeEngine(MacroParser parser) : IEngine
+public class NativeEngine : IEngine
 {
     /// <summary>
     /// Event raised when a macro execution is requested.

--- a/SomethingNeedDoing/LuaMacro/NLuaMacroEngine.cs
+++ b/SomethingNeedDoing/LuaMacro/NLuaMacroEngine.cs
@@ -104,20 +104,22 @@ public class NLuaMacroEngine(LuaModuleManager moduleManager, CleanupManager clea
             lua.RegisterClass<Svc>();
             moduleManager.RegisterAll(lua);
 
+            var nativeEngine = new NativeEngine();
+            nativeEngine.MacroExecutionRequested += (sender, e) =>
+                MacroExecutionRequested?.Invoke(this, e);
+
+            nativeEngine.LoopControlRequested += (sender, e) =>
+                LoopControlRequested?.Invoke(this, e);
+
+            var luaEngine = new LuaEngine();
+            luaEngine.MacroExecutionRequested += (sender, e) =>
+                MacroExecutionRequested?.Invoke(this, e);
+
             var engines = new List<IEngine>
             {
-                new NativeEngine(parser),
-                new LuaEngine(this)
+                nativeEngine,
+                luaEngine
             };
-
-            if (engines[0] is NativeEngine nativeEngine)
-            {
-                nativeEngine.MacroExecutionRequested += (sender, e) =>
-                    MacroExecutionRequested?.Invoke(this, e);
-
-                nativeEngine.LoopControlRequested += (sender, e) =>
-                    LoopControlRequested?.Invoke(this, e);
-            }
 
             var enginesModule = new EnginesModule(engines);
             enginesModule.Register(lua);


### PR DESCRIPTION
I believe this is at least some of a fix for the follow-up issues with https://github.com/Jaksuhn/SomethingNeedDoing/issues/69

The issue seemed to be around the `MacroExecutionRequested` hookup.

For `Native` macros (which were working) - this was done in `NLuaMacroEngine` with
```
            nativeEngine.MacroExecutionRequested += (sender, e) =>
                MacroExecutionRequested?.Invoke(this, e);

            nativeEngine.LoopControlRequested += (sender, e) =>
                LoopControlRequested?.Invoke(this, e);
```
i.e. `NativeEngine` => `NLuaMacroEngine`, and `this` passed to `Invoke` is `NLuaMacroEngine`

but for lua the existing code lived in `LuaEngine` and was
```
        luaEngine.MacroExecutionRequested += (sender, e) =>
            MacroExecutionRequested?.Invoke(this, e);
```
i.e. `NLuaMacroEngine` (`luaEngine` passed to the `LuaEngine` constructor) => `LuaEngine`, and `this` passed to `Invoke` is `LuaEngine`. So it was backwards from the Native implementation.

previously I think it worked because it `LuaEngine` was directly calling `NLuaMacroEngine.StartMacro` (although I assume that bypassed all the other handling and is why it didn't appear in the status window).

Change:
- move `MacroExecutionRequested` hookup from `LuaEngine` to `NLuaMacroEngine` and invert semantic direction (to match how Native handles it)
- remove unused `NLuaMacroEngine` arg from `LuaEngine` constructor
- remove unused `MacroParser` arg from `NativeEngine` constructor

Testing
- Lua runs as expected:
  <img width="776" height="540" alt="ffxiv_dx11_2025-08-14_11-14-11" src="https://github.com/user-attachments/assets/fdc32f50-e8c3-425f-abfb-9dca384f11f2" />
  - Stopping the macro _kinda_ works - it's not propagating the stop to child macros (with the above test, I think the yield is executed as a child macro?). I do have the setting enabled that should propagate it. When I press stop, the echo doesn't execute so the stop is definitely at least stopping the overall macro execution (can also press stop again on the child macro anyways if needed and that stops it instantly, so this is 'partially-working')
    ![ffxiv_dx11_2025-08-14_11-41-13](https://github.com/user-attachments/assets/5bbbc728-2328-452f-a1cd-7b625952ed12)
  - Pause does not work. Pressing pause will show the macro as paused in the status window, but execution will continue.
    ![ffxiv_dx11_2025-08-14_11-42-13](https://github.com/user-attachments/assets/b7796ace-9a1c-462b-ae7d-676b76ba225c)
- Native also (still) works
  - Stopping works (unsure about child macro - dunno how to spawn one with native).
  - Pause does not work. (same behavior as lua)
  