### PR TITLE
AtkValues and Nodes get problem

### DIFF
--- a/SomethingNeedDoing/LuaMacro/Wrappers/AddonWrapper.cs
+++ b/SomethingNeedDoing/LuaMacro/Wrappers/AddonWrapper.cs
@@ -25,26 +25,25 @@ public unsafe class AddonWrapper(string name) : IWrapper
     [LuaDocs] public AtkValueWrapper GetAtkValue(int index) => new(Addon->AtkValues[index]);
 
     [LuaDocs]
-    public unsafe IEnumerable<AtkValueWrapper> AtkValues
+    public AtkValueWrapper[] AtkValues
     {
         get
         {
-            foreach (var v in AtkValuesList)
-                yield return new AtkValueWrapper(v);
+            return AtkValuesList.Select(v => new AtkValueWrapper(v)).ToArray();
         }
     }
 
     [LuaDocs] public NodeWrapper GetNode(params int[] nodeIds) => new(Addon, nodeIds);
 
     [LuaDocs]
-    public unsafe IEnumerable<NodeWrapper> Nodes
+    public NodeWrapper[] Nodes
     {
         get
         {
-            foreach (var node in NodeList)
-                yield return new NodeWrapper(node);
+            return NodeList.Select(v => new NodeWrapper(v)).ToArray();
         }
     }
+
 }
 
 public unsafe class NodeWrapper : IWrapper


### PR DESCRIPTION
I have a problem
how to get AtkValues and Nodes in NLua

IEnumerable<AtkValueWrapper> AtkValues and IEnumerable<NodeWrapper> Nodes
I try some methods to get Wrapper,but all faild. and there is no function to get AtkValues Count, if I can use Count or Length    to get all atkvalues with function GetAtkValue(index)
1> for in ipair

local addon = Addons.GetAddon("ContextMenu")
if addon.AtkValues then
    for index, wrapper in ipairs(addon.AtkValues) do
        local valueString = wrapper.ValueString
        print(string.format("index %d: %s", index, valueString))
    end
end

result: nothing happen ,faild to get any AtkValueWrapper

2> for in pair

local addon = Addons.GetAddon("ContextMenu")
if addon.AtkValues then
    for key, wrapper in pairs(addon.AtkValues) do
        if wrapper and wrapper.ValueString then
            local val = wrapper.ValueString
            print("index:", key, "v:", val)
        end
    end
end

result:00:37:51.644 | Error | [SomethingNeedDoing] [NLuaMacroEngine] Error executing macro 33a954e6-1147-476f-b2a1-d4473c56f33b: NLua.Exceptions.LuaScriptException: [string "chunk"]:8: bad argument #1 to 'for iterator' (table expected, got SomethingNeedDoing.LuaMacro.Wrappers.AddonWrapper+<get_AtkValues>d__14, SomethingNeedDoing, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null)

