### PR TITLE
feat(inventory): add MoveItemSlotToSlot to InventoryItemWrapper

### DIFF
--- a/SomethingNeedDoing/LuaMacro/Modules/InventoryModule.cs
+++ b/SomethingNeedDoing/LuaMacro/Modules/InventoryModule.cs
@@ -228,6 +228,11 @@ public unsafe class InventoryModule : LuaModuleBase
             => InventoryManager.Instance()->MoveItemSlot(Container, (ushort)Slot, destinationContainer, GetFirstEmptySlot(destinationContainer, ArmouryContainer), true);
 
         [LuaDocs]
+        [Changelog("14.12")]
+        public void MoveItemSlotToSlot(InventoryType destinationContainer, int destinationSlot)
+            => InventoryManager.Instance()->MoveItemSlot(Container, (ushort)Slot, destinationContainer, (ushort)destinationSlot, true);
+
+        [LuaDocs]
         [Changelog("13.58")]
         public void LowerQuality() => AgentInventoryContext.Instance()->LowerItemQuality(Item, Container, Slot, 0);
 


### PR DESCRIPTION
Adds `MoveItemSlotToSlot(InventoryType destinationContainer, int destinationSlot)` to `InventoryItemWrapper`.

The existing `MoveItemSlot` always targets the first empty slot in the destination container. This new method lets a script target a specific slot index, which is useful when you want to merge two item stacks.
